### PR TITLE
Simplify log output

### DIFF
--- a/Google.Cloud.Functions.Invoker/Logging/FactoryLoggerProvider.cs
+++ b/Google.Cloud.Functions.Invoker/Logging/FactoryLoggerProvider.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Google.Cloud.Functions.Invoker.Logging
+{
+    /// <summary>
+    /// Simple logger provider that just calls a factory method each time it's asked for logger.
+    /// </summary>
+    internal class FactoryLoggerProvider : ILoggerProvider
+    {
+        private readonly Func<string, ILogger> _factory;
+
+        internal FactoryLoggerProvider(Func<string, ILogger> factory) =>
+            _factory = factory;
+
+        public ILogger CreateLogger(string categoryName) => _factory(categoryName);
+
+        public void Dispose()
+        {
+            // No-op
+        }
+    }
+}

--- a/Google.Cloud.Functions.Invoker/Logging/JsonConsoleLogger.cs
+++ b/Google.Cloud.Functions.Invoker/Logging/JsonConsoleLogger.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Google.Cloud.Functions.Invoker.Logging
+{
+    /// <summary>
+    /// Logger that writes a single line of JSON to the console per event, in a format that Google Cloud Logging can consume and display nicely.
+    /// </summary>
+    internal class JsonConsoleLogger : LoggerBase
+    {
+        internal JsonConsoleLogger(string category) : base(category)
+        {
+        }
+
+        public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            string severity = logLevel switch
+            {
+                LogLevel.Trace => "DEBUG",
+                LogLevel.Debug => "DEBUG",
+                LogLevel.Information => "INFO",
+                LogLevel.Warning => "WARNING",
+                LogLevel.Error => "ERROR",
+                LogLevel.Critical => "CRITICAL",
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+            };
+
+            string message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+            StringBuilder builder = new StringBuilder();
+            JsonWriter writer = new JsonTextWriter(new StringWriter(builder));
+            writer.WriteStartObject();
+            writer.WritePropertyName("message");
+            writer.WriteValue(message);
+            writer.WritePropertyName("log_name");
+            writer.WriteValue(Category);
+            if (exception != null)
+            {
+                writer.WritePropertyName("exception");
+                writer.WriteValue(exception.ToString());
+            }
+            writer.WritePropertyName("severity");
+            writer.WriteValue(severity);
+
+            // If we have format params and its more than just the original message add them.
+            if (state is IEnumerable<KeyValuePair<string, object>> formatParams &&
+                ContainsFormatParameters(formatParams))
+            {
+                writer.WritePropertyName("format_parameters");
+                writer.WriteStartObject();
+                foreach (var pair in formatParams)
+                {
+                    string key = pair.Key;
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        continue;
+                    }
+                    if (char.IsDigit(key[0]))
+                    {
+                        key = "_" + key;
+                    }
+                    writer.WritePropertyName(key);
+                    writer.WriteValue(pair.Value?.ToString() ?? "");
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+            Console.WriteLine(builder);
+
+            // Checks that fields is:
+            // - Non-empty
+            // - Not just a single entry with a key of "{OriginalFormat}"
+            // so we can decide whether or not to populate a struct with it.
+            bool ContainsFormatParameters(IEnumerable<KeyValuePair<string, object>> fields)
+            {
+                using (var iterator = fields.GetEnumerator())
+                {
+                    // No fields? Nothing to format.
+                    if (!iterator.MoveNext())
+                    {
+                        return false;
+                    }
+                    // If the first entry isn't the original format, we definitely want to create a struct
+                    if (iterator.Current.Key != "{OriginalFormat}")
+                    {
+                        return true;
+                    }
+                    // If the first entry *is* the original format, we want to create a struct
+                    // if and only if there's at least one more entry.
+                    return iterator.MoveNext();
+                }
+            }
+        }
+    }
+}

--- a/Google.Cloud.Functions.Invoker/Logging/LoggerBase.cs
+++ b/Google.Cloud.Functions.Invoker/Logging/LoggerBase.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Google.Cloud.Functions.Invoker.Logging
+{
+    /// <summary>
+    /// Base class for loggers that don't do any of their own filtering, and don't support scopes.
+    /// </summary>
+    internal abstract class LoggerBase : ILogger
+    {
+        protected string Category { get; }
+
+        protected LoggerBase(string category) =>
+            Category = category;
+
+        // We don't really support scopes
+        public IDisposable BeginScope<TState>(TState state) => SingletonDisposable.Instance;
+
+        // Note: log level filtering is handled by other logging infrastructure, so we don't do any of it here.
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public abstract void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter);
+
+        // Used for scope handling.
+        private class SingletonDisposable : IDisposable
+        {
+            internal static readonly SingletonDisposable Instance = new SingletonDisposable();
+            private SingletonDisposable() { }
+            public void Dispose() { }
+        }
+    }
+}

--- a/Google.Cloud.Functions.Invoker/Logging/SimpleConsoleLogger.cs
+++ b/Google.Cloud.Functions.Invoker/Logging/SimpleConsoleLogger.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Google.Cloud.Functions.Invoker.Logging
+{
+    internal class SimpleConsoleLogger : LoggerBase
+    {
+        internal SimpleConsoleLogger(string category) : base(category)
+        {
+        }
+
+        public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            string message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            // Note: these are deliberately the same values used by ASP.NET Core's console logger.
+            string briefLevel = logLevel switch
+            {
+                LogLevel.Trace => "trce",
+                LogLevel.Debug => "dbug",
+                LogLevel.Information => "info",
+                LogLevel.Warning => "warn",
+                LogLevel.Error => "fail",
+                LogLevel.Critical => "crit",
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+            };
+
+            Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff'Z'} [{Category}] [{briefLevel}] {message}");
+        }
+    }
+}


### PR DESCRIPTION
- Remove the warning about overwriting a default value
- Use a one-line-per-message console writer, either simply text, or
  JSON if we detect we're on k-native via the K_SERVICE environment
  variable

Admittedly this loses the "prettiness" of coloured output etc - but it's a lot more appropriate for microservices in general. (And the JSON output looks great in Stackdriver. Once we've got an alpha02 nuget package, I'll deploy to Cloud Run to test that. It's tricky to do before then.)