### PR TITLE
Use "category" in the JSON logger instead of "log_name"

### DIFF
--- a/Google.Cloud.Functions.Invoker/Logging/JsonConsoleLogger.cs
+++ b/Google.Cloud.Functions.Invoker/Logging/JsonConsoleLogger.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Functions.Invoker.Logging
             writer.WriteStartObject();
             writer.WritePropertyName("message");
             writer.WriteValue(message);
-            writer.WritePropertyName("log_name");
+            writer.WritePropertyName("category");
             writer.WriteValue(Category);
             if (exception != null)
             {


### PR DESCRIPTION
We could potentially use "logName" which would be picked up by
Google Cloud Logging, but we'd almost certainly want a prefix there,
which wouldn't be easy to predict. We could add that as an extra
property in the JSON later if we want to.