### PR TITLE
Add integration testing functionality and documentation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,5 @@ export Configuration=Release
 dotnet build src
 dotnet test src
 dotnet build examples
+dotnet test examples
 dotnet pack src

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ This repository contains the source code for three NuGet packages:
 - [Google.Cloud.Functions.Invoker](https://www.nuget.org/packages/Google.Cloud.Functions.Invoker)
   contains code to start up an ASP.NET Core webserver based on
   conventional environment variables etc.
+- [Google.Cloud.Functions.Invoker.Testing](https://www.nuget.org/packages/Google.Cloud.Functions.Invoker.Testing)
+  contains code to help simplify testing functions.
 - [Google.Cloud.Functions.Templates](https://www.nuget.org/packages/Google.Cloud.Functions.Templates)
   contains templates for the `dotnet` command line to create a very
   simple getting-started experience.
@@ -37,3 +39,8 @@ projects in `src` to allow for easy development. However, the expectation
 is that unless they use unreleased features, each example could be
 extracted from the repo, project references changed to package
 references, and the example should still work.
+
+## Additional documentation in this directory:
+
+- [Testing Functions](testing.md)
+- [Examples](examples.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,38 @@
+# Examples
+
+The [examples](../examples) directory contains source code to
+demonstrate various features of the Functions Framework. This page
+provides commentary and explanation of those examples.
+
+The examples are configured to refer to the projects in the
+[src](../src) directory rather than the NuGet packages for simple
+experimentation when building new features, but any function using
+released functionality can be made standalone simply by converting
+the project reference into a package reference.
+
+## SimpleHttpFunction
+
+The [SimpleHttpFunction](../examples/Google.Cloud.Functions.Examples.SimpleHttpFunction)
+function is the result of creating a new HTTP function via the
+template using the following command line:
+
+```sh
+dotnet new gcf-http
+```
+
+## SimpleEventFunction
+
+The [SimpleEventFunction](../examples/Google.Cloud.Functions.Examples.SimpleEventFunction)
+function is the result of creating a new Cloud Event function via the
+template using the following command line:
+
+```sh
+dotnet new gcf-event
+```
+
+## Integration Tests
+
+The [IntegrationTests](../examples/Google.Cloud.Functions.Examples.IntegrationTests)
+directory contains integration tests for the example functions.
+These can also be used as examples of how functions can be tested.
+See the [testing documentation](testing.md) for more details.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,66 @@
+# Testing Functions
+
+In many cases, the unit tests for a function won't need to use the
+Functions Framework at all. They can simply create the function
+instance directly, specifying appropriate forms of any dependencies, and
+invoke the function.
+
+Integration testing is relatively straightforward, based on the
+regular ASP.NET Core pattern of creating a test server, then
+invoking it with an appropriately-configured `HttpClient`.
+
+## Creating an IHostBuilder with EntryPoint.CreateHostBuilder
+
+The invoker [EntryPoint](../src/Google.Cloud.Functions.Invoker.EntryPoint) class
+not only contains the `Main` method used automatically to start the
+server, but an overloaded `CreateHostBuilder` method. The generic,
+parameterless overload expects the type argument to be a function
+type, and creates a suitable `IHostBuilder` with no additional
+environment.
+
+A non-generic overload accepting a `Type` parameter is equivalent to
+the generic overload, but without needing to know the function type
+at compile-time.
+
+Finally, there's a non-generic overload accepting a string-to-string
+dictionary of fake environment variables and a function assembly.
+This provides more control for scenarios where you may want to
+simulate running in a container, or running in a Knative environment.
+
+The `IHostBuilder` can be used in conjunction with the
+[Microsoft.AspNetCore.TestHost](https://www.nuget.org/packages/Microsoft.AspNetCore.TestHost)
+NuGet package to create a test server and execute requests against it.
+
+See [SimpleHttpFunctionTest](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest.cs)
+for an example of this.
+
+## Creating a FunctionTestServer
+
+Using `TestHost` directly can be slightly verbose - it's not too bad
+for an occasional test, but not something you'd want to use in a
+large number of tests. The
+[Google.Cloud.Functions.Invoker.Testing](../src/Google.Cloud.Functions.Invoker.Testing)
+package provides a [FunctionTestServer](../src/Google.Cloud.Functions.Invoker.Testing/FunctionTestServer)
+class to simplify this. The generic `FunctionTestServer<TFunction>`
+class is a derived class allowing you to use the function type as a
+type argument, avoiding the need for any other configuration.
+
+`FunctionTestServer` is typically used in one of three ways. The
+examples given below are for xUnit, but other test frameworks provide
+similar functionality.
+
+- It can be constructed directly within the test. This should be in the context
+  of a `using` statement to dispose of the server afterwards. See
+  [SimpleHttpFunctionTest_WithTestServerInTest](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInTest.cs)
+  for an example of this.
+- It can be constructed directly in the test class constructor,
+  and then disposed in an `IDisposable.Dispose()` implementation, which is
+  automatically called by xUnit. This means a new server is constructed
+  for each test. See
+  [SimpleHttpFunctionTest_WithTestServerInCtor](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInCtor.cs)
+  for an example of this.
+- It can be automatically constructed by xUnit as part of a fixture, then disposed
+  of automatically when the fixture is disposed. This means a single server
+  is used for all tests in the fixture. See
+  [SimpleHttpFunctionTest_WithTestServerFixture](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerFixture.cs)
+  for an example of this.

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -1,17 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyOriginatorKeyFile>../GoogleApis.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker.Testing\Google.Cloud.Functions.Invoker.Testing.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest.cs
@@ -1,0 +1,48 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Invoker;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Examples.IntegrationTests
+{
+    /// <summary>
+    /// Simple example of an integration test against a Cloud Function, without using
+    /// the Google.Cloud.Functions.Invoker.Testing package.
+    /// </summary>
+    public class SimpleHttpFunctionTest
+    {
+        [Fact]
+        public async Task FunctionWritesHelloFunctionsFramework()
+        {
+            var builder = EntryPoint
+                .CreateHostBuilder<SimpleHttpFunction.Function>()
+                .ConfigureWebHost(builder => builder.UseTestServer());
+            using (var server = await builder.StartAsync())
+            {
+                var client = server.GetTestServer().CreateClient();
+                
+                // Make a request to the function, and test that the response looks how we expect it to.
+                var response = await client.GetAsync("request-uri");
+                response.EnsureSuccessStatusCode();
+                var content = await response.Content.ReadAsStringAsync();
+
+                Assert.Equal("Hello, Functions Framework.", content);
+            }
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerFixture.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerFixture.cs
@@ -1,0 +1,46 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Invoker.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Examples.IntegrationTests
+{
+    /// <summary>
+    /// Simple example of an integration test creating a <see cref="FunctionTestServer{TFunction}"/>
+    /// as a fixture. This uses the same test server across multiple tests.
+    /// </summary>
+    public class SimpleHttpFunctionTest_WithTestServerFixture : IClassFixture<FunctionTestServer<SimpleHttpFunction.Function>>
+    {
+        // The function test server created automatically by xUnit. This will be disposed after all tests have run.
+        private readonly FunctionTestServer<SimpleHttpFunction.Function> _server;
+
+        public SimpleHttpFunctionTest_WithTestServerFixture(FunctionTestServer<SimpleHttpFunction.Function> server) =>
+            _server = server;
+
+        [Fact]
+        public async Task FunctionWritesHelloFunctionsFramework()
+        {
+            var client = _server.CreateClient();
+
+            // Make a request to the function, and test that the response looks how we expect it to.
+            var response = await client.GetAsync("request-uri");
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("Hello, Functions Framework.", content);
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInCtor.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInCtor.cs
@@ -1,0 +1,52 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Invoker.Testing;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Examples.IntegrationTests
+{
+    /// <summary>
+    /// Simple example of an integration test creating a <see cref="FunctionTestServer{TFunction}"/>
+    /// in the constructor. This uses a different test server for each test, but makes the setup common
+    /// across all tests.
+    /// </summary>
+    public class SimpleHttpFunctionTest_WithTestServerInCtor : IDisposable
+    {
+        // The function test server created in the constructor.
+        private readonly FunctionTestServer<SimpleHttpFunction.Function> _server;
+
+        public SimpleHttpFunctionTest_WithTestServerInCtor() =>
+            _server = new FunctionTestServer<SimpleHttpFunction.Function>();
+
+        // Dispose of the function test server, which in turn disposes of the underlying test server.
+        // xUnit calls this automatically when a test is complete.
+        public void Dispose() => _server.Dispose();
+
+        [Fact]
+        public async Task FunctionWritesHelloFunctionsFramework()
+        {
+            var client = _server.CreateClient();
+
+            // Make a request to the function, and test that the response looks how we expect it to.
+            var response = await client.GetAsync("request-uri");
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("Hello, Functions Framework.", content);
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInTest.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerInTest.cs
@@ -1,0 +1,43 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Invoker.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Examples.IntegrationTests
+{
+    /// <summary>
+    /// Simple example of an integration test creating a <see cref="FunctionTestServer{TFunction}"/>
+    /// inside a test.
+    /// </summary>
+    public class SimpleHttpFunctionTest_WithTestServerInTest
+    {
+        [Fact]
+        public async Task FunctionWritesHelloFunctionsFramework()
+        {
+            using (var server = new FunctionTestServer<SimpleHttpFunction.Function>())
+            {
+                var client = server.CreateClient();
+
+                // Make a request to the function, and test that the response looks how we expect it to.
+                var response = await client.GetAsync("request-uri");
+                response.EnsureSuccessStatusCode();
+                var content = await response.Content.ReadAsStringAsync();
+
+                Assert.Equal("Hello, Functions Framework.", content);
+            }
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.sln
+++ b/examples/Google.Cloud.Functions.Examples.sln
@@ -7,9 +7,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Fram
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Invoker", "..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj", "{994A5912-B44E-41B6-B086-3A4420EDA8DC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Invoker.Testing", "..\src\Google.Cloud.Functions.Invoker.Testing\Google.Cloud.Functions.Invoker.Testing.csproj", "{40BAC92F-40EA-41AC-852E-D2D04B934243}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.SimpleEventFunction", "Google.Cloud.Functions.Examples.SimpleEventFunction\Google.Cloud.Functions.Examples.SimpleEventFunction.csproj", "{31959486-3FA8-4CDF-84E7-109A875C32F6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.SimpleHttpFunction", "Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj", "{41A3F818-E524-46DF-9EFF-1E92201956AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.IntegrationTests", "Google.Cloud.Functions.Examples.IntegrationTests\Google.Cloud.Functions.Examples.IntegrationTests.csproj", "{79F4BB7D-FB15-4B3D-B618-686D3A265834}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +73,30 @@ Global
 		{41A3F818-E524-46DF-9EFF-1E92201956AA}.Release|x64.Build.0 = Release|Any CPU
 		{41A3F818-E524-46DF-9EFF-1E92201956AA}.Release|x86.ActiveCfg = Release|Any CPU
 		{41A3F818-E524-46DF-9EFF-1E92201956AA}.Release|x86.Build.0 = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|x64.Build.0 = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Debug|x86.Build.0 = Debug|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|x64.ActiveCfg = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|x64.Build.0 = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|x86.ActiveCfg = Release|Any CPU
+		{79F4BB7D-FB15-4B3D-B618-686D3A265834}.Release|x86.Build.0 = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|x64.Build.0 = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Debug|x86.Build.0 = Debug|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|x64.ActiveCfg = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|x64.Build.0 = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|x86.ActiveCfg = Release|Any CPU
+		{40BAC92F-40EA-41AC-852E-D2D04B934243}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Google.Cloud.Functions.Invoker.Testing/FunctionTestServer.cs
+++ b/src/Google.Cloud.Functions.Invoker.Testing/FunctionTestServer.cs
@@ -1,0 +1,88 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+
+namespace Google.Cloud.Functions.Invoker.Testing
+{
+    /// <summary>
+    /// A test server to simplify in-memory testing.
+    /// </summary>
+    public class FunctionTestServer : IDisposable
+    {
+        /// <summary>
+        /// The underlying <see cref="TestServer"/> hosting the function.
+        /// </summary>
+        public TestServer Server { get; }
+
+        private FunctionTestServer(IHostBuilder builder)
+        {
+            var host = builder
+                .ConfigureWebHost(webBuilder => webBuilder.UseTestServer())
+                .Build();
+            host.Start();
+            Server = host.GetTestServer();
+        }
+
+        /// <summary>
+        /// Creates a FunctionServerFactory for the specified environment and function assembly.
+        /// </summary>
+        /// <param name="environment">The fake environment variables to use when constructing the server.</param>
+        /// <param name="functionAssembly">The assembly containing the target function.</param>
+        public FunctionTestServer(IReadOnlyDictionary<string, string> environment, Assembly functionAssembly)
+            : this(EntryPoint.CreateHostBuilder(environment, Preconditions.CheckNotNull(functionAssembly, nameof(functionAssembly))))
+        {
+        }
+
+        /// <summary>
+        /// Creates a FunctionServerFactory for the specified function type.
+        /// </summary>
+        /// <param name="functionType">The function type to host in the server.</param>
+        public FunctionTestServer(Type functionType)
+            : this(EntryPoint.CreateHostBuilder(functionType))
+        {
+        }
+
+        /// <summary>
+        /// Creates an <see cref="HttpClient"/> to make requests to the test server.
+        /// </summary>
+        /// <returns>An <see cref="HttpClient"/> that will connect to <see cref="Server"/> by default.</returns>
+        public HttpClient CreateClient() => Server.CreateClient();
+
+        /// <summary>
+        /// Disposes of the test server.
+        /// </summary>
+        public void Dispose() => Server.Dispose();
+    }
+
+    /// <summary>
+    /// Generic version of <see cref="FunctionTestServer"/>, making it particularly simple to specify as
+    /// a test fixture.
+    /// </summary>
+    /// <typeparam name="TFunction">The function type to host in the server</typeparam>
+    public class FunctionTestServer<TFunction> : FunctionTestServer
+    {
+        /// <summary>
+        /// Constructs a new instance serving <typeparamref name="TFunction"/>.
+        /// </summary>
+        public FunctionTestServer() : base(typeof(TFunction))
+        {
+        }
+    }
+}

--- a/src/Google.Cloud.Functions.Invoker.Testing/Google.Cloud.Functions.Invoker.Testing.csproj
+++ b/src/Google.Cloud.Functions.Invoker.Testing/Google.Cloud.Functions.Invoker.Testing.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyOriginatorKeyFile>../GoogleApis.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <Deterministic>true</Deterministic>
+    <OutputType>Library</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>1.0.0-alpha02</Version>
+    <IsPackable>True</IsPackable>
+    <Title>Google Cloud Functions Framework Invoker Testing</Title>
+    <Authors>Google LLC</Authors>
+    <Description>Simplifies integration tests for Google Cloud Functions Framework functions.</Description>
+    <PackageTags>google;cloud;functions</PackageTags>
+    <!-- TODO: Find a Functions-specific icon URL. -->
+    <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
+    <PackageIcon>NuGetIcon.png</PackageIcon>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/GoogleCloudPlatform/functions-framework-dotnet</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/GoogleCloudPlatform/functions-framework-dotnet</RepositoryUrl>
+    <Nullable>Enable</Nullable>
+
+    <!-- Stop Visual Studio adding a launchSettings.properties file -->
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../NuGetIcon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Google.Cloud.Functions.Invoker.Testing/Preconditions.cs
+++ b/src/Google.Cloud.Functions.Invoker.Testing/Preconditions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Functions.Invoker.Testing
+{
+    /// <summary>
+    /// Simple preconditions class, internal to avoid any conflicts and compatibility issues.
+    /// </summary>
+    internal static class Preconditions
+    {
+        internal static T CheckNotNull<T>(T value, string paramName) =>
+            value ?? throw new ArgumentNullException(paramName);
+    }
+}

--- a/src/Google.Cloud.Functions.Invoker.Tests/EntryPointTest.cs
+++ b/src/Google.Cloud.Functions.Invoker.Tests/EntryPointTest.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Framework;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Invoker.Tests
+{
+    public class EntryPointTest
+    {
+        [Fact]
+        public async Task CreateHostBuilder()
+        {
+            var builder = EntryPoint
+                .CreateHostBuilder<SimpleFunction>()
+                .ConfigureWebHost(builder => builder.UseTestServer());
+            using (var server = await builder.StartAsync())
+            {
+                var client = server.GetTestServer().CreateClient();
+
+                var response = await client.GetAsync("relativePath");
+                response.EnsureSuccessStatusCode();
+                var content = await response.Content.ReadAsStringAsync();
+                Assert.Equal("Test message", content);
+            }
+        }
+
+        public class SimpleFunction : IHttpFunction
+        {
+            public async Task HandleAsync(HttpContext context)
+            {
+                await context.Response.WriteAsync("Test message");
+            }
+        }
+    }
+}

--- a/src/Google.Cloud.Functions.Invoker/ConfigurationVariableProvider.cs
+++ b/src/Google.Cloud.Functions.Invoker/ConfigurationVariableProvider.cs
@@ -28,8 +28,8 @@ namespace Google.Cloud.Functions.Invoker
         internal static ConfigurationVariableProvider Combine(ConfigurationVariableProvider primary, ConfigurationVariableProvider secondary) =>
             new CombinedVariableProvider(primary, secondary);
 
-        internal static ConfigurationVariableProvider FromDictionary(IDictionary<string, string> dictionary) =>
-            new DictionaryVariableProvider(dictionary);
+        internal static ConfigurationVariableProvider FromDictionary(IReadOnlyDictionary<string, string> environment) =>
+            new DictionaryVariableProvider(environment);
 
         /// <summary>
         /// Converts command line parameters into a <see cref="ConfigurationVariableProvider"/>, allowing a transformation
@@ -102,10 +102,10 @@ namespace Google.Cloud.Functions.Invoker
         /// </summary>
         private sealed class DictionaryVariableProvider : ConfigurationVariableProvider
         {
-            private readonly IDictionary<string, string> _environment;
+            private readonly IReadOnlyDictionary<string, string> _environment;
 
-            internal DictionaryVariableProvider(IDictionary<string, string> environment) =>
-                _environment = environment;
+            internal DictionaryVariableProvider(IReadOnlyDictionary<string, string> environment) =>
+                _environment = Preconditions.CheckNotNull(environment, nameof(environment));
 
             protected override string? GetVariable(string variable) =>
                 _environment.TryGetValue(variable, out var value) ? value : null;

--- a/src/Google.Cloud.Functions.Invoker/EntryPoint.cs
+++ b/src/Google.Cloud.Functions.Invoker/EntryPoint.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -60,19 +61,56 @@ namespace Google.Cloud.Functions.Invoker
             // doesn't matter much. Potentially catch exceptions during configuration, but let any
             // during web server execution propagate.
             var environment = FunctionEnvironment.Create(functionAssembly, args, ConfigurationVariableProvider.System);
-            IHostBuilder builder = Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder => webBuilder
-                    .ConfigureLogging(logging =>
-                    {
-                        logging.ClearProviders();
-                        logging.AddProvider(environment.LoggerProvider);
-                    })
-                    .ConfigureKestrel(serverOptions => serverOptions.Listen(environment.Address, environment.Port))
-                    .ConfigureServices(environment.ConfigureServices)
-                    .Configure(app => app.Run(environment.RequestHandler))
-                );
-            await builder.Build().RunAsync();
+            await environment.CreateHostBuilder().Build().RunAsync();
             return 0;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IWebHostBuilder"/> for the function type specified by
+        /// <typeparamref name="TFunction"/>. This is a convenience method equivalent to calling
+        /// <see cref="CreateHostBuilder(IReadOnlyDictionary{string, string}, Assembly)"/>, passing in a dictionary
+        /// that only contains the function target environment variable and the assembly
+        /// containing the function type. This method is primarily used for writing integration tests.
+        /// See the documentation for a fuller example.
+        /// </summary>
+        /// <returns>A host builder that can be used for integration testing.</returns>
+        /// <typeparam name="TFunction">The function type to host.</typeparam>
+        public static IHostBuilder CreateHostBuilder<TFunction>() => CreateHostBuilder(typeof(TFunction));
+
+        /// <summary>
+        /// Creates an <see cref="IWebHostBuilder"/> for the function type specified by
+        /// <paramref name="functionType"/>. This is a convenience method equivalent to calling
+        /// <see cref="CreateHostBuilder(IReadOnlyDictionary{string, string}, Assembly)"/>, passing in a dictionary
+        /// that only contains the function target environment variable and the assembly
+        /// containing the function type. This method is primarily used for writing integration tests
+        /// where the function type isn't known at compile time.
+        /// </summary>
+        /// <param name="functionType">The function type to host.</param>
+        /// <returns>A host builder that can be used for integration testing.</returns>
+        public static IHostBuilder CreateHostBuilder(Type functionType)
+        {
+            Preconditions.CheckNotNull(functionType, nameof(functionType));
+            var functionTarget = functionType.FullName ?? throw new ArgumentException("Target function type has no name.");
+            var environment = new Dictionary<string, string> { { FunctionTargetEnvironmentVariable, functionTarget } };
+            return CreateHostBuilder(environment, functionType.Assembly);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IWebHostBuilder"/> as if the environment variables are set as per <paramref name="environment"/>.
+        /// The actual system environment variables are ignored. Command line arguments are not supported, as (by design) everything
+        /// that can be specified on the command line can also be specified via environment variables.
+        /// This method is primarily used for writing integration tests where a high degree of control is required,
+        /// for example to simulate the difference between running in a container or not.
+        /// </summary>
+        /// <param name="environment">The fake environment variables to use when constructing the host builder.</param>
+        /// <param name="functionAssembly">The assembly containing the target function. May be null, in which case the calling assembly
+        /// is used.</param>
+        /// <returns>A host builder that can be used for integration testing.</returns>
+        public static IHostBuilder CreateHostBuilder(IReadOnlyDictionary<string, string> environment, Assembly? functionAssembly = null)
+        {
+            var variables = ConfigurationVariableProvider.FromDictionary(environment);
+            var functionEnvironment = FunctionEnvironment.Create(functionAssembly ?? Assembly.GetCallingAssembly(), new string[0], variables);
+            return functionEnvironment.CreateHostBuilder();
         }
     }
 }

--- a/src/Google.Cloud.Functions.sln
+++ b/src/Google.Cloud.Functions.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Fram
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Invoker.Tests", "Google.Cloud.Functions.Invoker.Tests\Google.Cloud.Functions.Invoker.Tests.csproj", "{E3EB87DB-08CB-4850-B4DA-A6ADBEA34A7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Invoker.Testing", "Google.Cloud.Functions.Invoker.Testing\Google.Cloud.Functions.Invoker.Testing.csproj", "{970964D0-CA4E-4418-9859-4CA971DAEA90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{E3EB87DB-08CB-4850-B4DA-A6ADBEA34A7D}.Release|x64.Build.0 = Release|Any CPU
 		{E3EB87DB-08CB-4850-B4DA-A6ADBEA34A7D}.Release|x86.ActiveCfg = Release|Any CPU
 		{E3EB87DB-08CB-4850-B4DA-A6ADBEA34A7D}.Release|x86.Build.0 = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|x64.Build.0 = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Debug|x86.Build.0 = Debug|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|x64.ActiveCfg = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|x64.Build.0 = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|x86.ActiveCfg = Release|Any CPU
+		{970964D0-CA4E-4418-9859-4CA971DAEA90}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This adds a new package, Google.Cloud.Functions.Invoker.Testing,
containing a test server - as well as methods in EntryPoint to just
create an IHostBuilder where that's more desirable.

The documentation here is roughly the level and style of
documentation I'm hoping to use for other features, such as
dependency injection.