### PR TITLE
Detect a potential problem with launching from Visual Studio, and give a nice error

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,3 +45,4 @@ references, additional MSBuild imports removed, and the example should still wor
 - [Testing Functions](testing.md)
 - [Examples](examples.md)
 - [Dependency Injection](dependency-injection.md)
+- [Microsoft.NET.Sdk.Web and launchSettings.json](launch-settings.md)

--- a/docs/launch-settings.md
+++ b/docs/launch-settings.md
@@ -1,0 +1,41 @@
+# Microsoft.NET.Sdk.Web and launchSettings.json
+
+You may well have reached this page due to a link in an exception,
+while trying to start the Functions Framework Invoker.
+
+If you start a project with an `Sdk` attribute of
+"Microsoft.NET.Sdk.Web" in Visual Studio, it will create a
+`launchSettings.json` file if one doesn't already exist, and pass a
+single string, `%LAUNCHER_ARGS%` to the `Main` method.
+
+That's useful for a regular ASP.NET Core application, but isn't
+appropriate for a Functions Framework application using the
+Google.Cloud.Functions.Framework.Invoker package which *always* uses
+Kestrel, gets its port from the `PORT` environment variable etc.
+
+There are three simple solutions to this issue. In order of
+simplicity and preference:
+
+- Change the `Sdk` attribute in the root element of your project
+  file to "Microsoft.NET.Sdk", and delete any existing
+  `launchSettings.json` file. At that point Visual Studio will
+  treat it as a regular console application project. Using the
+  Debugging property tab in Visual Studio will create a new
+  `launchSettings.json`, but the way that file is used does not
+  interfere with the Functions Framework Invoker.
+- Add an element
+  `<NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>`
+  within a `<PropertyGroup>` in your project file, and delete any
+  existing `launchSettings.json` file. That will stop Visual Studio
+  from creating a `launchSettings.json` file, so you won't experience
+  this problem.
+- Stop using the Functions Framework Invoker. If you want to run your
+  function as part of a regular ASP.NET Core app, you can do so - and
+  you *may* find it useful to still refer to the
+  Google.Cloud.Functions.Framework package, just not the invoker.
+
+There may be more complex options you wish to investigate if none
+of the above options work in your situation. It would be useful if
+you could [file an issue](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/issues/new)
+to provide some context, so we can help you find those options and
+perhaps work around the problem within the framework in the future.

--- a/src/Google.Cloud.Functions.Invoker.Tests/FunctionEnvironmentTest.cs
+++ b/src/Google.Cloud.Functions.Invoker.Tests/FunctionEnvironmentTest.cs
@@ -33,6 +33,15 @@ namespace Google.Cloud.Functions.Invoker.Tests
         private static readonly string[] Empty = new string[0];
 
         [Fact]
+        public void LaunchSettingsGiveInstructions()
+        {
+            // See https://github.com/GoogleCloudPlatform/functions-framework-dotnet/issues/41 for the background
+            var exception = AssertBadEnvironment(new[] { "%LAUNCHER_ARGS%" }, Empty);
+            // The exception should contain a message with a link to documentation.
+            Assert.Contains("https://github.com", exception.Message);
+        }
+
+        [Fact]
         public void Port_DefaultsTo8080()
         {
             var environment = CreateEnvironment(DefaultFunctionCommandLine, Empty);
@@ -186,7 +195,7 @@ namespace Google.Cloud.Functions.Invoker.Tests
             Assert.Equal(IPAddress.Loopback, environment.Address);
         }
 
-        private static void AssertBadEnvironment(string[] commandLine, string[] variables) =>
+        private static Exception AssertBadEnvironment(string[] commandLine, string[] variables) =>
             Assert.ThrowsAny<Exception>(() => CreateEnvironment(commandLine, variables));
 
         private static async Task AssertHttpFunctionType<T>(FunctionEnvironment environment) where T : IHttpFunction

--- a/src/Google.Cloud.Functions.Invoker/FunctionEnvironment.cs
+++ b/src/Google.Cloud.Functions.Invoker/FunctionEnvironment.cs
@@ -161,6 +161,10 @@ namespace Google.Cloud.Functions.Invoker
                 // For the convenience of running from the command line, treat a single command line variable as if it's a "--target" value.
                 if (commandLine.Length == 1)
                 {
+                    if (commandLine[0] == "%LAUNCHER_ARGS%")
+                    {
+                        throw new Exception("Unable to launch Web SDK project with launch settings. Please see https://github.com/GoogleCloudPlatform/functions-framework-dotnet/blob/master/docs/launch-settings.md");
+                    }
                     commandLine = new[] { "--target", commandLine[0] };
                 }
                 var commandLineVariables = ConfigurationVariableProvider.FromCommandLine(commandLine, CommandLineArgumentToVariableMapping);


### PR DESCRIPTION
It's reasonably infeasible to "just keep working" as far as I can tell. We
could potentially ignore the command line parameter, but we'd want
to work out what port VS thinks we're listening on etc. It's cleaner
just to give more information to the user.

Fixes #41