### PR TITLE
When in doubt, add more dependency injection

### DIFF
--- a/src/Google.Cloud.Functions.Framework.Tests/CloudEventAdapterTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/CloudEventAdapterTest.cs
@@ -14,6 +14,7 @@
 
 using CloudNative.CloudEvents;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -26,7 +27,7 @@ namespace Google.Cloud.Functions.Framework.Tests
         public async Task InvalidRequest_FunctionNotCalled()
         {
             var function = new TestCloudEventFunction();
-            var adapter = new CloudEventAdapter(function);
+            var adapter = new CloudEventAdapter(function, new NullLogger<CloudEventAdapter>());
             var context = new DefaultHttpContext();
             await adapter.HandleAsync(context);
             Assert.Equal(400, context.Response.StatusCode);
@@ -37,7 +38,7 @@ namespace Google.Cloud.Functions.Framework.Tests
         public async Task ValidRequest_FunctionCalled()
         {
             var function = new TestCloudEventFunction();
-            var adapter = new CloudEventAdapter(function);
+            var adapter = new CloudEventAdapter(function, new NullLogger<CloudEventAdapter>());
             string eventId = Guid.NewGuid().ToString();
             var context = new DefaultHttpContext
             {

--- a/src/Google.Cloud.Functions.Framework.Tests/LegacyEvents/LegacyEventAdapterTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/LegacyEvents/LegacyEventAdapterTest.cs
@@ -14,6 +14,7 @@
 
 using Google.Cloud.Functions.Framework.LegacyEvents;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -45,7 +46,7 @@ namespace Google.Cloud.Functions.Framework.Tests.LegacyEvents
                 executed = true;
                 return Task.CompletedTask;
             });
-            var adapter = new LegacyEventAdapter<StorageObject>(function);
+            var adapter = CreateAdapter(function);
 
             var httpContext = CreateHttpContext("storage.json");
             await adapter.HandleAsync(httpContext);
@@ -70,7 +71,7 @@ namespace Google.Cloud.Functions.Framework.Tests.LegacyEvents
                 executed = true;
                 return Task.CompletedTask;
             });
-            var adapter = new LegacyEventAdapter<FirestoreEvent>(function);
+            var adapter = CreateAdapter(function);
 
             var httpContext = CreateHttpContext("firestore_simple.json");
             await adapter.HandleAsync(httpContext);
@@ -167,7 +168,7 @@ namespace Google.Cloud.Functions.Framework.Tests.LegacyEvents
                 ret = data;
                 return Task.CompletedTask;
             });
-            var adapter = new LegacyEventAdapter<T>(function);
+            var adapter = CreateAdapter(function);
 
             var httpContext = CreateHttpContext(resource);
             await adapter.HandleAsync(httpContext);
@@ -193,7 +194,7 @@ namespace Google.Cloud.Functions.Framework.Tests.LegacyEvents
             {
                 throw new Exception("Function should not be called");
             });
-            var adapter = new LegacyEventAdapter<StorageObject>(function);
+            var adapter = CreateAdapter(function);
             var httpContext = new DefaultHttpContext
             {
                 Request =
@@ -218,6 +219,9 @@ namespace Google.Cloud.Functions.Framework.Tests.LegacyEvents
 
             public Task HandleAsync(T payload, Context context) => _func(payload, context);
         }
+
+        private static LegacyEventAdapter<T> CreateAdapter<T>(ILegacyEventFunction<T> function) where T : class =>
+            new LegacyEventAdapter<T>(function, new NullLogger<LegacyEventAdapter<T>>());
 
         private static HttpContext CreateHttpContext(string resourceName) =>
             new DefaultHttpContext

--- a/src/Google.Cloud.Functions.Invoker.Tests/DependencyInjectionTest.cs
+++ b/src/Google.Cloud.Functions.Invoker.Tests/DependencyInjectionTest.cs
@@ -70,7 +70,7 @@ namespace Google.Cloud.Functions.Invoker.Tests
                 using (var scope = provider.CreateScope())
                 {
                     var context = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
-                    await environment.RequestHandler(context);
+                    await environment.Execute(context);
                     return (context.Items[Dependency1Key], context.Items[Dependency2Key]);
                 }
             }

--- a/src/Google.Cloud.Functions.Invoker/Logging/SimpleConsoleLogger.cs
+++ b/src/Google.Cloud.Functions.Invoker/Logging/SimpleConsoleLogger.cs
@@ -44,6 +44,12 @@ namespace Google.Cloud.Functions.Invoker.Logging
             };
 
             Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff'Z'} [{Category}] [{briefLevel}] {message}");
+            // Note: it's not ideal to break out of the "one line per log entry" approach here, but there's no particularly
+            // nice way of getting all the relevant information otherwise.
+            if (exception is object)
+            {
+                Console.WriteLine(exception);
+            }
         }
     }
 }


### PR DESCRIPTION
Admittedly this makes everything "that bit more magic" - but in the existing code, we create some objects ourselves and ask the framework to create others.
This PR asks ASP.NET Core DI to do more of the work - we just identify which types we need.

That then allows the rest of the PR, adding more logging in adapters... without changing any invoker code.