### PR TITLE
Rename the TimeZoneConverter function to Function

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Function.cs
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Function.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Functions.Examples.TimeZoneConverter
     ///   Format: extended ISO yyyy-MM-ddTHH:mm:ss with optional subsecond digits.</item>
     /// </list>
     /// </summary>
-    public sealed class TimeZoneConverter : IHttpFunction
+    public sealed class Function : IHttpFunction
     {
         private static readonly JsonSerializerOptions s_serializerOptions = new JsonSerializerOptions
         { 
@@ -50,7 +50,7 @@ namespace Google.Cloud.Functions.Examples.TimeZoneConverter
         /// Constructs a converter using the given time zone provider and source.
         /// </summary>
         /// <param name="provider">The time zone provider to use.</param>
-        public TimeZoneConverter(IDateTimeZoneProvider provider) =>
+        public Function(IDateTimeZoneProvider provider) =>
             _timeZoneProvider = provider;
 
         /// <summary>

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Startup.cs
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Startup.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Functions.Examples.TimeZoneConverter
 {
     /// <summary>
     /// Startup class to provide the NodaTime built-in TZDB (IANA) date time zone provider
-    /// as a dependency to <see cref="TimeZoneConverter"/>.
+    /// as a dependency to <see cref="Function"/>.
     /// </summary>
     public class Startup : FunctionsStartup
     {


### PR DESCRIPTION
This is partly to avoid the "type name collision with namespace
name" aspect, and partly because I think I'm landing on Function
being a conventional entry point name in the same way that Program
is for a console application.

Fixes #45.