### PR TITLE
Allow a simple project/package reference choice for examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,12 +4,20 @@ The [examples](../examples) directory contains source code to
 demonstrate various features of the Functions Framework. This page
 provides commentary and explanation of those examples.
 
-The examples are configured to refer to the projects in the
-[src](../src) directory rather than the NuGet packages for simple
-experimentation when building new features, but any function using
-released functionality can be made standalone simply by converting
-the project reference into a package reference and removing the
-imports for MSBuild files from the Invoker project.
+The examples all use the NuGet packages by default, to make them
+easier to deploy and more representative of the normal developer
+experience. However, if you wish to experiment with changes to the
+Functions Framework - whether that's developing new features or
+fixing a bug - you can do so by setting the MSBuild property
+`LocalFunctionsFramework` to any non-empty value. Typically it's
+most convenient to do this by setting an environment variable of the
+same name before running `dotnet` or launching Visual Studio.
+
+> **Tip**  
+> If you start Visual Studio from the command line, it uses the
+> environment variables from that command line session. This is a
+> simple way of developing against the local framework just for a
+> single session.
 
 Some examples include multiple classes in a single source file. This
 is purely to make the examples easier to follow when browsing on
@@ -33,6 +41,16 @@ template using the following command line:
 
 ```sh
 dotnet new gcf-event
+```
+
+## SimpleLegacyEventFunction
+
+The [SimpleLegacyEventFunction](../examples/Google.Cloud.Functions.Examples.SimpleLegacyEventFunction)
+function is the result of creating a new Legacy Event function via the
+template using the following command line:
+
+```sh
+dotnet new gcf-legacy-event
 ```
 
 ## VbHttpFunction

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -14,4 +14,23 @@
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
+
+  <!-- 
+    - Use the LocalFunctionsFramework property (usually specified via an
+    - environment variable) to enable local development, targeting the
+    - local projects instead of the NuGet packages.
+    -->
+  <Import Condition="'$(LocalFunctionsFramework)' != ''"
+          Project="../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets" />
+  <Import Condition="'$(LocalFunctionsFramework)' != ''"
+          Project="../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props" />
+
+  <ItemGroup Condition="'$(LocalFunctionsFramework)' != ''">
+    <!-- Even if some projects don't actually need these, it doesn't hurt to have them. -->
+    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
+    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.Testing.csproj" />
+    <PackageReference Remove="Google.Cloud.Functions.Framework" />
+    <PackageReference Remove="Google.Cloud.Functions.Testing" />
+    <PackageReference Remove="Google.Cloud.Functions.Invoker" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets" />
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props" />
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
+
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,8 +7,8 @@
   <ItemGroup>
     <Compile Include="Function.fs" />
   </ItemGroup>
-
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -11,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker.Testing\Google.Cloud.Functions.Invoker.Testing.csproj" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker.Testing" Version="1.0.0-alpha04" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -1,11 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets" />
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props" />
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>  
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleLegacyEventFunction/Google.Cloud.Functions.Examples.SimpleLegacyEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleLegacyEventFunction/Google.Cloud.Functions.Examples.SimpleLegacyEventFunction.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets" />
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props" />
-  <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.0.0-beta03" />
-    <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets" />
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props" />
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
     <PackageReference Include="NodaTime" Version="3.0.0-beta01" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Google.Cloud.Functions.Examples.VbEventFunction</RootNamespace>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>
-  <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Google.Cloud.Functions.Invoker\Google.Cloud.Functions.Invoker.csproj" />
-  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Google.Cloud.Functions.Examples.VbHttpFunction</RootNamespace>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha04" />
+  </ItemGroup>
 </Project>

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,17 +3,22 @@ the templates:
 
 - Google.Cloud.Functions.Examples.SimpleHttpFunction
 - Google.Cloud.Functions.Examples.SimpleEventFunction
+- Google.Cloud.Functions.Examples.SimpleLegacyEventFunction
 - Google.Cloud.Functions.Examples.FSharpHttpFunction
 - Google.Cloud.Functions.Examples.FSharpEventFunction
 - Google.Cloud.Functions.Examples.VbHttpFunction
 - Google.Cloud.Functions.Examples.VbEventFunction
 
-In each case, after creating the project, the following changes are
-applied:
+In each case, after creating the project, a copyright notice is
+added to the code.
 
-- Change the package reference for Google.Cloud.Functions.Invoker
-  into a local project reference
-- Import the MSBuild files from the Invoker project (these are
-  imported automatically when the library is used as a package
-  reference)
-- Add a copyright notice to the source code
+When built as they are, the example projects refer to packages on
+nuget.org, which makes deployment to Google Cloud Functions simpler,
+and is closer to the regular developer experience.
+
+To build against the local version of the Functions Framework (in
+the `src` directory), set an MSBuild property of
+`LocalFunctionsFramework` to any non-empty value. This is often most
+simply done from the command line. You can then either run the
+example with `dotnet run`, or start Visual Studio with the
+environment variable set.

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -15,14 +15,6 @@ generate() {
   
   # Create the project and source files
   dotnet new $TEMPLATE_NAME -lang $LANG > /dev/null
-
-  # Change the package reference to a project reference
-  dotnet remove package Google.Cloud.Functions.Invoker > /dev/null
-  dotnet add reference ../../src/Google.Cloud.Functions.Invoker > /dev/null
-
-  # Explicitly import the MSBuild targets (not necessary for NuGet packages)
-  sed -i '2 i \ \ <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.targets"/>' *.*proj
-  sed -i '3 i \ \ <Import Project="../../src/Google.Cloud.Functions.Invoker/targets/Google.Cloud.Functions.Invoker.props"/>' *.*proj
   
   # Add copyright notices
   for source in *.??

--- a/src/Google.Cloud.Functions.Invoker/EntryPoint.cs
+++ b/src/Google.Cloud.Functions.Invoker/EntryPoint.cs
@@ -49,6 +49,7 @@ namespace Google.Cloud.Functions.Invoker
         /// </returns>
         public static async Task<int> StartAsync(Assembly functionAssembly, string[] args)
         {
+            Console.WriteLine("Running locally");
             // Clear out the ASPNETCORE_URLS environment variable in order to avoid a warning when we start the server.
             // An alternative would be to *use* the environment variable, but as it's populated (with a non-ideal value) by
             // default, I suspect that would be tricky.

--- a/update-project-references.sh
+++ b/update-project-references.sh
@@ -8,3 +8,9 @@ for proj in $(find src/Google.Cloud.Functions.Templates/templates -name '*proj')
 do
   sed -i -e "s/Include=\"Google.Cloud.Functions.Invoker\" Version=\".*\"/Include=\"Google.Cloud.Functions.Invoker\" Version=\"$VERSION\"/g" $proj
 done
+
+for proj in $(find examples -name '*proj')
+do
+  sed -i -e "s/Include=\"Google.Cloud.Functions.Invoker\" Version=\".*\"/Include=\"Google.Cloud.Functions.Invoker\" Version=\"$VERSION\"/g" $proj
+  sed -i -e "s/Include=\"Google.Cloud.Functions.Invoker.Testing\" Version=\".*\"/Include=\"Google.Cloud.Functions.Invoker.Testing\" Version=\"$VERSION\"/g" $proj
+done


### PR DESCRIPTION
By default, all examples now reference NuGet packages. But specifying "LocalFunctionsFramework" as a property (e.g. via an environment variable) removes the package references and adds project references instead, for local development.

Fixes #53.