### PR TITLE
PROTOTYPE ONLY: Sample of how "replying to an event" might be handled.

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.EventFunctionWithReply/Function.cs
+++ b/examples/Google.Cloud.Functions.Examples.EventFunctionWithReply/Function.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using CloudNative.CloudEvents;
+using Google.Cloud.Functions.Framework;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Examples.EventFunctionWithReply
+{
+    // Just a demo function that publishes a reply with a sample event.
+    public class Function : ICloudEventFunctionWithReply
+    {
+        private readonly ILogger _logger;
+
+        public Function(ILogger<Function> logger) => _logger = logger;
+
+        /// <inheritdoc />
+        public Task<CloudEvent?> HandleAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Handling event {id}", cloudEvent.Id);
+
+            var newEvent = new CloudEvent(
+                type: "reply-type",
+                source: new Uri("http://127.0.0.1/event/source"),
+                id: Guid.NewGuid().ToString(),
+                time: DateTime.UtcNow)
+            {
+                Data = $"This is a reply to {cloudEvent.Id}",
+                DataContentType = new ContentType("text/plain")
+            };
+
+            _logger.LogInformation("Returning event {id}", newEvent.Id);
+            return Task.FromResult<CloudEvent?>(newEvent);
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.EventFunctionWithReply/Google.Cloud.Functions.Examples.EventFunctionWithReply.csproj
+++ b/examples/Google.Cloud.Functions.Examples.EventFunctionWithReply/Google.Cloud.Functions.Examples.EventFunctionWithReply.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Bring in the right project imports automatically. -->
+    <LocalFunctionsFramework>True</LocalFunctionsFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.sln
+++ b/examples/Google.Cloud.Functions.Examples.sln
@@ -43,7 +43,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Exam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.CustomConfiguration", "Google.Cloud.Functions.Examples.CustomConfiguration\Google.Cloud.Functions.Examples.CustomConfiguration.csproj", "{743A84EF-9B19-4E52-9FF1-38DBB54221F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.TestableDependencies", "Google.Cloud.Functions.Examples.TestableDependencies\Google.Cloud.Functions.Examples.TestableDependencies.csproj", "{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.TestableDependencies", "Google.Cloud.Functions.Examples.TestableDependencies\Google.Cloud.Functions.Examples.TestableDependencies.csproj", "{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.EventFunctionWithReply", "Google.Cloud.Functions.Examples.EventFunctionWithReply\Google.Cloud.Functions.Examples.EventFunctionWithReply.csproj", "{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -307,6 +309,18 @@ Global
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x64.Build.0 = Release|Any CPU
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x86.Build.0 = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|x64.Build.0 = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Debug|x86.Build.0 = Debug|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|x64.ActiveCfg = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|x64.Build.0 = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|x86.ActiveCfg = Release|Any CPU
+		{56E74F1D-36A1-4CDC-94E4-BD2BA5DC4431}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Google.Cloud.Functions.Framework/CloudEventWithReplyAdapter.cs
+++ b/src/Google.Cloud.Functions.Framework/CloudEventWithReplyAdapter.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Framework
+{
+    /// <summary>
+    /// An adapter to implement an HTTP function based on an <see cref="ICloudEventFunctionWithReply"/>,
+    /// automatically publishing any reply event via an <see cref="ICloudEventPublisher"/>.
+    /// </summary>
+    public class CloudEventWithReplyAdapter : IHttpFunction
+    {
+        private readonly ICloudEventFunctionWithReply _function;
+        private readonly ICloudEventPublisher _publisher;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a new instance of the adapter.
+        /// </summary>
+        /// <param name="function">The function to handle the event.</param>
+        /// <param name="publisher">The event publisher to use if the function returns a new event.</param>
+        /// <param name="logger">The logger to use in case of failures when deserializing.</param>
+        public CloudEventWithReplyAdapter(
+            ICloudEventFunctionWithReply function,
+            ICloudEventPublisher publisher,
+            ILogger<CloudEventWithReplyAdapter> logger) =>
+            (_function, _publisher, _logger) = (function, publisher, logger);
+
+        /// <inheritdoc />
+        public async Task HandleAsync(HttpContext context)
+        {
+            var cloudEvent = await context.Request.ReadCloudEventAsync();
+            // Note: ReadCloudEventAsync appears never to actually return null as it's documented to.
+            // Instead, we use the presence of properties required by the spec to determine validity.
+            if (!IsValidEvent(cloudEvent))
+            {
+                context.Response.StatusCode = 400;
+                _logger.LogError("Request did not contain a valid cloud event");
+                return;
+            }
+            var reply = await _function.HandleAsync(cloudEvent, context.RequestAborted);
+            if (reply is object)
+            {
+                await _publisher.PublishAsync(reply, context.RequestAborted);
+            }
+        }
+
+        private static bool IsValidEvent([NotNullWhen(true)] CloudEvent? cloudEvent) =>
+            cloudEvent is object &&
+            !string.IsNullOrEmpty(cloudEvent.Id) &&
+            cloudEvent.Source is object &&
+            !string.IsNullOrEmpty(cloudEvent.Type);
+    }
+}

--- a/src/Google.Cloud.Functions.Framework/DemoCloudEventPublisher.cs
+++ b/src/Google.Cloud.Functions.Framework/DemoCloudEventPublisher.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Framework
+{
+    /// <summary>
+    /// Just a sample of a Cloud Event Publisher - this just writes to the console.
+    /// </summary>
+    public class DemoCloudEventPublisher : ICloudEventPublisher
+    {
+        /// <inheritdoc />
+        public Task PublishAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
+        {
+            var formatter = new JsonEventFormatter();
+            byte[] data = formatter.EncodeStructuredEvent(cloudEvent, out _);
+            Console.WriteLine($"Publishing Cloud Event {cloudEvent.Id}:");
+            Console.WriteLine(Encoding.UTF8.GetString(data));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Google.Cloud.Functions.Framework/ICloudEventFunctionWithReply.cs
+++ b/src/Google.Cloud.Functions.Framework/ICloudEventFunctionWithReply.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Framework
+{
+    /// <summary>
+    /// Similar to <see cref="ICloudEventFunction"/>, but with an optional
+    /// event in the reply, which is automatically published.
+    /// </summary>
+    public interface ICloudEventFunctionWithReply
+    {
+        /// <summary>
+        /// Asynchronously handles the specified Cloud Event, optionally returning a Cloud Event to publish
+        /// as a response.
+        /// </summary>
+        /// <param name="cloudEvent">The Cloud Event extracted from the request.</param>
+        /// <param name="cancellationToken">A cancellation token which indicates if the request is aborted.</param>
+        /// <returns>A task representing the potentially-asynchronous handling of the event. If the result
+        /// within the task is non-null, that event is published automatically.</returns>
+        Task<CloudEvent?> HandleAsync(CloudEvent cloudEvent, CancellationToken cancellationToken);
+    }
+}

--- a/src/Google.Cloud.Functions.Framework/ICloudEventPublisher.cs
+++ b/src/Google.Cloud.Functions.Framework/ICloudEventPublisher.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Framework
+{
+    /// <summary>
+    /// A publisher for Cloud Events.
+    /// </summary>
+    public interface ICloudEventPublisher
+    {
+        /// <summary>
+        /// Publishes the specified event
+        /// </summary>
+        /// <param name="cloudEvent">The event to publish.</param>
+        /// <param name="cancellationToken">A cancellation token for the asynchronous operation.</param>
+        /// <returns></returns>
+        Task PublishAsync(CloudEvent cloudEvent, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
A different function might add a dependency on ICloudEventPublisher and publish any number of events during function execution.

(This is not intended to be merged - it's for the sake of discussion.)

This doesn't have nearly as much commentary as I'd like to include, but I've run out of time for the day. Hopefully it makes some kind of sense!

cc @meteatamel 