### PR TITLE
Update GCF event conversion for Storage source/subject

### DIFF
--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
@@ -27,20 +27,21 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
     {
         // Checks a basic mapping for each event source
         [Theory]
-        [InlineData("storage.json", "com.google.cloud.storage.object.finalize.v0", "//storage.googleapis.com/projects/_/buckets/some-bucket/objects/Test.cs")]
-        [InlineData("legacy_storage_change.json", "com.google.cloud.storage.object.change.v0", "//storage.googleapis.com/projects/_/buckets/sample-bucket/objects/MyFile#1588778055917163")]
-        [InlineData("firestore_simple.json", "com.google.cloud.firestore.document.write.v0", "//firestore.googleapis.com/projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to")]
-        [InlineData("pubsub_text.json", "com.google.cloud.pubsub.topic.publish.v0", "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test")]
-        [InlineData("legacy_pubsub.json", "com.google.cloud.pubsub.topic.publish.v0", "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test")]
-        [InlineData("firebase-db1.json", "com.google.cloud.firebase.database.write.v0", "//firebase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz")]
-        [InlineData("firebase-auth1.json", "com.google.cloud.firebase.auth.user.create.v0", "//firebase.googleapis.com/projects/my-project-id")]
-        [InlineData("firebase-auth2.json", "com.google.cloud.firebase.auth.user.delete.v0", "//firebase.googleapis.com/projects/my-project-id")]
-        public async Task ConvertGcfEvent(string resourceName, string expectedType, string expectedSource)
+        [InlineData("storage.json", "com.google.cloud.storage.object.finalize.v0", "//storage.googleapis.com/projects/_/buckets/some-bucket", "objects/folder/Test.cs")]
+        [InlineData("legacy_storage_change.json", "com.google.cloud.storage.object.change.v0", "//storage.googleapis.com/projects/_/buckets/sample-bucket", "objects/MyFile")]
+        [InlineData("firestore_simple.json", "com.google.cloud.firestore.document.write.v0", "//firestore.googleapis.com/projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to", null)]
+        [InlineData("pubsub_text.json", "com.google.cloud.pubsub.topic.publish.v0", "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", null)]
+        [InlineData("legacy_pubsub.json", "com.google.cloud.pubsub.topic.publish.v0", "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", null)]
+        [InlineData("firebase-db1.json", "com.google.cloud.firebase.database.write.v0", "//firebase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz", null)]
+        [InlineData("firebase-auth1.json", "com.google.cloud.firebase.auth.user.create.v0", "//firebase.googleapis.com/projects/my-project-id", null)]
+        [InlineData("firebase-auth2.json", "com.google.cloud.firebase.auth.user.delete.v0", "//firebase.googleapis.com/projects/my-project-id", null)]
+        public async Task ConvertGcfEvent(string resourceName, string expectedType, string expectedSource, string expectedSubject)
         {
             var context = GcfEventResources.CreateHttpContext(resourceName);
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request);
             Assert.Equal(expectedType, cloudEvent.Type);
             Assert.Equal(new Uri(expectedSource), cloudEvent.Source);
+            Assert.Equal(expectedSubject, cloudEvent.Subject);
         }
 
         // Checks everything we know about a single event
@@ -53,9 +54,9 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             Assert.Equal("1147091835525187", cloudEvent.Id);
             Assert.Equal("com.google.cloud.storage.object.finalize.v0", cloudEvent.Type);
             Assert.Equal(new DateTime(2020, 4, 23, 7, 38, 57, 772), cloudEvent.Time);
-            Assert.Equal(new Uri("//storage.googleapis.com/projects/_/buckets/some-bucket/objects/Test.cs"), cloudEvent.Source);
+            Assert.Equal(new Uri("//storage.googleapis.com/projects/_/buckets/some-bucket"), cloudEvent.Source);
+            Assert.Equal("objects/folder/Test.cs", cloudEvent.Subject);
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
-            Assert.Null(cloudEvent.Subject);
             Assert.Null(cloudEvent.DataSchema);
             Assert.IsType<string>(cloudEvent.Data);
         }

--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/storage.json
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/storage.json
@@ -5,7 +5,7 @@
       "eventType": "google.storage.object.finalize",
       "resource": {
          "service": "storage.googleapis.com",
-         "name": "projects/_/buckets/some-bucket/objects/Test.cs",
+         "name": "projects/_/buckets/some-bucket/objects/folder/Test.cs",
          "type": "storage#object"
       }
    },
@@ -15,13 +15,13 @@
       "crc32c": "rTVTeQ==",
       "etag": "CNHZkbuF/ugCEAE=",
       "generation": "1587627537231057",
-      "id": "some-bucket/Test.cs/1587627537231057",
+      "id": "some-bucket/folder/Test.cs/1587627537231057",
       "kind": "storage#object",
       "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
-      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/Test.cs?generation=1587627537231057\u0026alt=media",
+      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
       "metageneration": "1",
-      "name": "Test.cs",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/Test.cs",
+      "name": "folder/Test.cs",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
       "size": "352",
       "storageClass": "MULTI_REGIONAL",
       "timeCreated": "2020-04-23T07:38:57.230Z",


### PR DESCRIPTION
Other events *may* need a similar treatment - we're still finalizing
the source/subject for Firebase and Firestore events.