### PR TITLE
Add an in-memory log provider to the test server

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,3 +64,31 @@ similar functionality.
   is used for all tests in the fixture. See
   [SimpleHttpFunctionTest_WithTestServerFixture](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleHttpFunctionTest_WithTestServerFixture.cs)
   for an example of this.
+  
+## Testing logs with FunctionTestServer
+
+`FunctionTestServer` augments the default logging with an in-memory
+logger provider, allowing you to retrieve logs by category using the
+`GetLogEntries` method. See
+[SimpleDependencyInjectionTest.cs](../examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleDependencyInjectionTest.cs)
+for an example of how this can be used.
+
+Currently the functionality is somewhat primitive, but should meet
+the demands of most users. Aspects that may change later include:
+
+- The logger provider is configured after any other services. If you
+  manually configure services during startup, eagerly loading
+  singletons, the in-memory logger will not be configured.
+- If the test server is constructed as part of a fixture, the logs
+  persist between tests. (A `ClearLogs` method allows you to
+  explicitly clear the logs if you need to.)
+- The logger provider is unconditionally installed, and has an
+  unlimited buffer size. This makes the test server inappropriate
+  for long-running soak tests, for example. In the future we may
+  provide options to disable the in-memory logger, or limit its
+  log entry buffer.
+- The logger only provides the log message rather than separate
+  parts of the log entry that may be available, such as placeholder
+  replacement values.
+- The logger does not support log scopes; all log entries are stored
+  in a flat structure.

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Invoker.Testing" Version="1.0.0-alpha07" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleDependencyInjectionTest.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/SimpleDependencyInjectionTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Invoker.Testing;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Functions.Examples.IntegrationTests
+{
+    public class SimpleDependencyInjectionTest
+    {
+        [Fact]
+        public async Task LogEntryIsRecorded()
+        {
+            using (var server = new FunctionTestServer<SimpleDependencyInjection.Function>())
+            {
+                // We shouldn't have any log entries (for the function's category) at the start of the test.
+                Assert.Empty(server.GetLogEntries(typeof(SimpleDependencyInjection.Function)));
+
+                var client = server.CreateClient();
+
+                // Make a request to the function.
+                var response = await client.GetAsync("sample-path");
+                response.EnsureSuccessStatusCode();
+
+                // Check that we got the expected log entry.
+
+                var logs = server.GetLogEntries(typeof(SimpleDependencyInjection.Function));
+                var entry = Assert.Single(logs);
+
+                Assert.Equal(LogLevel.Information, entry.Level);
+                Assert.Equal("Function called with path /sample-path", entry.Message);
+            }
+        }
+    }
+}

--- a/src/Google.Cloud.Functions.Invoker.Testing/TestLogEntry.cs
+++ b/src/Google.Cloud.Functions.Invoker.Testing/TestLogEntry.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Google.Cloud.Functions.Invoker.Testing
+{
+    /// <summary>
+    /// A very simplified representation of a log entry, aimed at testing.
+    /// </summary>
+    public sealed class TestLogEntry
+    {
+        /// <summary>
+        /// The category name of the log entry.
+        /// </summary>
+        public string CategoryName { get; }
+
+        /// <summary>
+        /// The level of the log entry.
+        /// </summary>
+        public LogLevel Level { get; }
+
+        /// <summary>
+        /// The exception in the log entry, or null if there was no exception.
+        /// </summary>
+        public Exception? Exception { get; }
+
+        /// <summary>
+        /// The event ID of the log entry.
+        /// </summary>
+        public EventId EventId { get; }
+
+        /// <summary>
+        /// The message of the log entry.
+        /// </summary>
+        public string Message { get; }
+
+        private TestLogEntry(string categoryName, LogLevel level, EventId eventId, string message, Exception? exception) =>
+            (CategoryName, Level, EventId, Message, Exception) =
+            (categoryName, level, eventId, message, exception);
+
+        internal static TestLogEntry Create<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+            return new TestLogEntry(categoryName, logLevel, eventId, message, exception);
+        }
+    }
+}

--- a/src/Google.Cloud.Functions.Invoker.Testing/TestLoggerProvider.cs
+++ b/src/Google.Cloud.Functions.Invoker.Testing/TestLoggerProvider.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Functions.Invoker.Testing
+{
+    /// <summary>
+    /// A test logger that accumulates logs in memory.
+    /// </summary>
+    internal sealed class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentDictionary<string, ConcurrentQueue<TestLogEntry>> _logsByCategory =
+            new ConcurrentDictionary<string, ConcurrentQueue<TestLogEntry>>();
+
+        public ILogger CreateLogger(string categoryName) => new TestLogger(
+            categoryName,
+            _logsByCategory.GetOrAdd(categoryName, _ => new ConcurrentQueue<TestLogEntry>()));
+
+        internal void Clear() => _logsByCategory.Clear();
+
+        /// <summary>
+        /// Returns a list of log entries for the given category name. If no logs have been
+        /// written for the given category, an empty list is returned.
+        /// </summary>
+        /// <param name="categoryName">The category name for which to get log entries.</param>
+        /// <returns>A list of log entries for the given category name.</returns>
+        internal List<TestLogEntry> GetLogEntries(string categoryName) =>
+            _logsByCategory.TryGetValue(categoryName, out var entries)
+            ? entries.ToList() : new List<TestLogEntry>();
+
+        public void Dispose()
+        {
+            // No-op
+        }
+
+        private class TestLogger : ILogger
+        {
+            private readonly string _categoryName;
+            private readonly ConcurrentQueue<TestLogEntry> _logEntries;
+
+            internal TestLogger(string categoryName, ConcurrentQueue<TestLogEntry> logEntries) =>
+                (_categoryName, _logEntries) = (categoryName, logEntries);
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+                _logEntries.Enqueue(TestLogEntry.Create(_categoryName, logLevel, eventId, state, exception, formatter));
+
+            // We don't really support scopes
+            public IDisposable BeginScope<TState>(TState state) => SingletonDisposable.Instance;
+
+            // Note: log level filtering is handled by other logging infrastructure, so we don't do any of it here.
+            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+            // Used for scope handling.
+            private class SingletonDisposable : IDisposable
+            {
+                internal static readonly SingletonDisposable Instance = new SingletonDisposable();
+                private SingletonDisposable() { }
+                public void Dispose() { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
(The docs state some limitations at the moment, but I think it's worth including even so.)

Fixes #93.