### PR TITLE
Release 1.0.0-alpha08

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet
 First, install the template package into the .NET tooling:
 
 ```sh
-dotnet new -i Google.Cloud.Functions.Templates::1.0.0-alpha07
+dotnet new -i Google.Cloud.Functions.Templates::1.0.0-alpha08
 ```
 
 Next, create a directory for your project, and use `dotnet new` to

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,7 +1,8 @@
 # Version History
 
-## 1.0.0-alpha08 (not yet released)
+## 1.0.0-alpha08 (released 2020-07-07)
 
+- Added an in-memory logger provider to the test server
 - Moved the event data classes out of the Functions Framework into
   `Google.Events.*`. We have a dependency on `Google.Events` but
   not on any specific serialization strategy.

--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker.Testing" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker.Testing" Version="1.0.0-alpha08" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha03" />

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/CommonProperties.xml
+++ b/src/CommonProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-alpha07</Version>
+    <Version>1.0.0-alpha08</Version>
   </PropertyGroup>
 
   <!-- Build information -->

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
     <PackageReference Include="Google.Events.SystemTextJson" Version="1.0.0-alpha03" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha07" />
+    <PackageReference Include="Google.Cloud.Functions.Invoker" Version="1.0.0-alpha08" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes since 1.0.0-alpha07

- Added an in-memory logger provider to the test server
- Moved the event data classes out of the Functions Framework into
  `Google.Events.*`. We have a dependency on `Google.Events` but
  not on any specific serialization strategy.
- Changed the shape of the PubSub CloudEvent data to match the event
  on Cloud Run. (The message is wrapped in another class that will
  eventually contain the subscription name.)
- Separated out the bucket name (source) and object name (subject) for
  storage CloudEvents.