### PR TITLE
Clone recursively when building a release

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -12,7 +12,7 @@ rm -rf tmp
 mkdir tmp
 
 git clone https://github.com/GoogleCloudPlatform/functions-framework-dotnet.git \
-  --depth 1 -b $1 tmp/release
+  --depth 1 -b $1 --recursive tmp/release
   
 cd tmp/release
 ./build.sh


### PR DESCRIPTION
Without this, dotnet pack complains that SourceLink may be broken due to the conformance test submodule.

I'm not entirely sure it's correct, but cloning recursively makes
the problem go away in a cheap way.