### PR TITLE
Docs: Add more documentation for running examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -145,7 +145,8 @@ Sample deployment:
 ```sh
 gcloud functions deploy vb-http \
   --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.VbHttpFunction.Function
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -23,6 +23,30 @@ Some examples include multiple classes in a single source file. This
 is purely to make the examples easier to follow when browsing on
 GitHub.
 
+## Running and deploying
+
+Each example can be run locally from the command line by changing to
+the example directory and running
+
+```sh
+dotnet run
+```
+
+Alternatively, you can open the solution file in the `examples`
+directory, set the "Startup Project" to the example you want to run,
+and just press F5 to run.
+
+To deploy to Google Cloud Functions or Cloud Run, follow the
+[deployment guide](deployment.md). Every example uses a function
+class called `Function` in a namespace that's the same as the
+directory. For example, the entry point for the function in the
+`Google.Cloud.Functions.Examples.SimpleHttpFuntion` directory is
+`Google.Cloud.Functions.Examples.SimpleHttpFunction.Function`.
+
+A sample command line is given for each example, but you may need to
+adapt this to specify your own Google Cloud resources such as PubSub
+topics or Storage buckets.
+
 ## SimpleHttpFunction
 
 The [SimpleHttpFunction](../examples/Google.Cloud.Functions.Examples.SimpleHttpFunction)
@@ -31,6 +55,14 @@ template using the following command line:
 
 ```sh
 dotnet new gcf-http
+```
+
+Sample deployment:
+
+```sh
+gcloud functions deploy simple-http --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.SimpleHttpFunction.Function
 ```
 
 ## SimpleEventFunction
@@ -43,6 +75,17 @@ template using the following command line:
 dotnet new gcf-event
 ```
 
+This function expects Storage events, and logs details of the event it receives.
+
+Sample deployment:
+
+```sh
+gcloud functions deploy simple-event --runtime dotnet3 \
+  --trigger-event google.storage.object.finalize \
+  --trigger-resource <gcs-bucket-name> \
+  --entry-point Google.Cloud.Functions.Examples.SimpleEventFunction.Function
+```
+
 ## SimpleUntypedEventFunction
 
 The [SimpleUntypedEventFunction](../examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction)
@@ -51,6 +94,17 @@ template using the following command line:
 
 ```sh
 dotnet new gcf-untyped-event
+```
+
+This function can handle any event type, and logs some generic
+details of the event it receives.
+
+Sample deployment to listen to PubSub events:
+
+```sh
+gcloud functions deploy simple-untyped-event --runtime dotnet3 \
+  --trigger-topic <topic-id> \
+  --entry-point Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.Function
 ```
 
 ## VbHttpFunction
@@ -63,6 +117,14 @@ template using the following command line:
 dotnet new gcf-http -lang vb
 ```
 
+Sample deployment:
+
+```sh
+gcloud functions deploy vb-http --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.VbHttpFunction.Function
+```
+
 ## VbEventFunction
 
 The [VbEventFunction](../examples/Google.Cloud.Functions.Examples.VbEventFunction)
@@ -73,6 +135,16 @@ template using the following command line:
 dotnet new gcf-event -lang vb
 ```
 
+This function expects Storage events, and logs details of the event it receives.
+
+Sample deployment:
+
+```sh
+gcloud functions deploy vb-event --runtime dotnet3 \
+  --trigger-event google.storage.object.finalize \
+  --trigger-resource <gcs-bucket-name> \
+  --entry-point Google.Cloud.Functions.Examples.VbEventFunction.Function
+```
 
 ## VbUntypedEventFunction
 
@@ -85,6 +157,17 @@ template using the following command line:
 dotnet new gcf-untyped-event -lang vb
 ```
 
+This function can handle any event type, and logs some generic
+details of the event it receives.
+
+Sample deployment to listen to PubSub events:
+
+```sh
+gcloud functions deploy vb-untyped-event --runtime dotnet3 \
+  --trigger-topic <topic-id> \
+  --entry-point Google.Cloud.Functions.Examples.VbUntypedEventFunction.Function
+```
+
 ## FSharpHttpFunction
 
 The [FSharpHttpFunction](../examples/Google.Cloud.Functions.Examples.FSharpHttpFunction)
@@ -93,6 +176,14 @@ template using the following command line:
 
 ```sh
 dotnet new gcf-http -lang f#
+```
+
+Sample deployment:
+
+```sh
+gcloud functions deploy fsharp-http --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.FSharpHttpFunction.Function
 ```
 
 ## FSharpEventFunction
@@ -105,7 +196,18 @@ template using the following command line:
 dotnet new gcf-event -lang f#
 ```
 
-## FSharpEventFunction
+This function expects Storage events, and logs details of the event it receives.
+
+Sample deployment:
+
+```sh
+gcloud functions deploy fsharp-event --runtime dotnet3 \
+  --trigger-event google.storage.object.finalize \
+  --trigger-resource <gcs-bucket-name> \
+  --entry-point Google.Cloud.Functions.Examples.FSharpEventFunction.Function
+```
+
+## FSharpUntypedEventFunction
 
 The [FSharpUntypedEventFunction](../examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction)
 function is the result of creating a new untyped Cloud Event function via the
@@ -113,6 +215,17 @@ template using the following command line:
 
 ```sh
 dotnet new gcf-untyped-event -lang f#
+```
+
+This function can handle any event type, and logs some generic
+details of the event it receives.
+
+Sample deployment to listen to PubSub events:
+
+```sh
+gcloud functions deploy fsharp-untyped-event --runtime dotnet3 \
+  --trigger-topic <topic-id> \
+  --entry-point Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.Function
 ```
 
 ## SimpleDependencyInjection
@@ -123,6 +236,14 @@ any additional configuration.
 
 See the [dependency injection documentation](dependency-injection.md) for more details.
 
+Sample deployment:
+
+```sh
+gcloud functions deploy simple-dependency-injection --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.SimpleDependencyInjection.Function
+```
+
 ## AdvancedDependencyInjection
 
 The [AdvancedDependencyInjection](../examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection)
@@ -131,6 +252,14 @@ provided via a startup class, including scoped and singleton
 dependencies.
 
 See the [dependency injection documentation](dependency-injection.md) for more details.
+
+Sample deployment:
+
+```sh
+gcloud functions deploy advanced-dependency-injection --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.AdvancedDependencyInjection.Function
+```
 
 ## TimeZoneConverter
 
@@ -142,6 +271,14 @@ on the [IANA time zone database](https://www.iana.org/time-zones).
 See the [README.md file](../examples/Google.Cloud.Functions.Examples.TimeZoneConverter/README.md)
 for more details.
 
+Sample deployment:
+
+```sh
+gcloud functions deploy time-zone-converter --runtime dotnet3 \
+  --trigger-http --allow-unauthenticated \
+  --entry-point Google.Cloud.Functions.Examples.TimeZoneConverter.Function
+```
+
 ## StorageImageAnnotator
 
 The [StorageImageAnnotator](../examples/Google.Cloud.Functions.Examples.StorageImageAnnotator)
@@ -152,6 +289,15 @@ then writes the results as a new Storage object.
 
 See the [README.md file](../examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/README.md)
 for more details.
+
+Sample deployment:
+
+```sh
+gcloud functions deploy image-annotator --runtime dotnet3 \
+  --trigger-event google.storage.object.finalize \
+  --trigger-resource <gcs-bucket-name> \
+  --entry-point=Google.Cloud.Functions.Examples.StorageImageAnnotator.Function
+```
 
 ## Integration Tests
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -47,6 +47,19 @@ A sample command line is given for each example, but you may need to
 adapt this to specify your own Google Cloud resources such as PubSub
 topics or Storage buckets.
 
+> **Note for Windows users**  
+> The sample command lines shown below are split over multiple lines
+> for readability, using `\` as a line continuation character. That
+> allows the whole command line to be copied and pasted in one go
+> within Unix shells such as bash, but won't work in a single step on
+> the Windows command line. Copy and paste each line, removing the
+> trailing `\`, and execute as a single command. For example, the
+> command to deploy SimpleHttpFunction would be:
+>
+> ```sh
+> gcloud functions deploy simple-http --runtime dotnet3 --trigger-http --allow-unauthenticated --entry-point Google.Cloud.Functions.Examples.SimpleHttpFunction.Function
+> ```
+
 ## SimpleHttpFunction
 
 The [SimpleHttpFunction](../examples/Google.Cloud.Functions.Examples.SimpleHttpFunction)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -44,7 +44,7 @@ directory. For example, the entry point for the function in the
 `Google.Cloud.Functions.Examples.SimpleHttpFunction.Function`.
 
 A sample command line is given for each example, but you may need to
-adapt this to specify your own Google Cloud resources such as PubSub
+adapt this to specify your own Google Cloud resources such as Pub/Sub
 topics or Storage buckets.
 
 > **Note for Windows users**  
@@ -60,6 +60,12 @@ topics or Storage buckets.
 > gcloud functions deploy simple-http --runtime dotnet3 --trigger-http --allow-unauthenticated --entry-point Google.Cloud.Functions.Examples.SimpleHttpFunction.Function
 > ```
 
+Where environment variables are used in the command line (e.g. `$GCS_BUCKET_NAME`)
+you can substitute the bucket name directly into the command line, or set an environment
+variable to make it easier to run multiple command lines that all use the same
+value. The environment variables shown are not used by the `gcloud functions deploy`
+command itself; they're only shown here to indicate a "placeholder" value.
+
 ## SimpleHttpFunction
 
 The [SimpleHttpFunction](../examples/Google.Cloud.Functions.Examples.SimpleHttpFunction)
@@ -73,8 +79,10 @@ dotnet new gcf-http
 Sample deployment:
 
 ```sh
-gcloud functions deploy simple-http --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+gcloud functions deploy simple-http \
+  --runtime dotnet3 \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.SimpleHttpFunction.Function
 ```
 
@@ -93,9 +101,10 @@ This function expects Storage events, and logs details of the event it receives.
 Sample deployment:
 
 ```sh
-gcloud functions deploy simple-event --runtime dotnet3 \
+gcloud functions deploy simple-event \
+  --runtime dotnet3 \
   --trigger-event google.storage.object.finalize \
-  --trigger-resource <gcs-bucket-name> \
+  --trigger-resource $GCS_BUCKET_NAME \
   --entry-point Google.Cloud.Functions.Examples.SimpleEventFunction.Function
 ```
 
@@ -112,11 +121,12 @@ dotnet new gcf-untyped-event
 This function can handle any event type, and logs some generic
 details of the event it receives.
 
-Sample deployment to listen to PubSub events:
+Sample deployment to listen to Pub/Sub events:
 
 ```sh
-gcloud functions deploy simple-untyped-event --runtime dotnet3 \
-  --trigger-topic <topic-id> \
+gcloud functions deploy simple-untyped-event \
+  --runtime dotnet3 \
+  --trigger-topic $PUBSUB_TOPIC_NAME \
   --entry-point Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.Function
 ```
 
@@ -133,7 +143,8 @@ dotnet new gcf-http -lang vb
 Sample deployment:
 
 ```sh
-gcloud functions deploy vb-http --runtime dotnet3 \
+gcloud functions deploy vb-http \
+  --runtime dotnet3 \
   --trigger-http --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.VbHttpFunction.Function
 ```
@@ -153,9 +164,10 @@ This function expects Storage events, and logs details of the event it receives.
 Sample deployment:
 
 ```sh
-gcloud functions deploy vb-event --runtime dotnet3 \
+gcloud functions deploy vb-event \
+  --runtime dotnet3 \
   --trigger-event google.storage.object.finalize \
-  --trigger-resource <gcs-bucket-name> \
+  --trigger-resource $ \
   --entry-point Google.Cloud.Functions.Examples.VbEventFunction.Function
 ```
 
@@ -173,11 +185,12 @@ dotnet new gcf-untyped-event -lang vb
 This function can handle any event type, and logs some generic
 details of the event it receives.
 
-Sample deployment to listen to PubSub events:
+Sample deployment to listen to Pub/Sub events:
 
 ```sh
-gcloud functions deploy vb-untyped-event --runtime dotnet3 \
-  --trigger-topic <topic-id> \
+gcloud functions deploy vb-untyped-event \
+  --runtime dotnet3 \
+  --trigger-topic $PUBSUB_TOPIC_NAME \
   --entry-point Google.Cloud.Functions.Examples.VbUntypedEventFunction.Function
 ```
 
@@ -194,8 +207,10 @@ dotnet new gcf-http -lang f#
 Sample deployment:
 
 ```sh
-gcloud functions deploy fsharp-http --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+gcloud functions deploy fsharp-http \
+  --runtime dotnet3 \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.FSharpHttpFunction.Function
 ```
 
@@ -214,9 +229,10 @@ This function expects Storage events, and logs details of the event it receives.
 Sample deployment:
 
 ```sh
-gcloud functions deploy fsharp-event --runtime dotnet3 \
+gcloud functions deploy fsharp-event \
+  --runtime dotnet3 \
   --trigger-event google.storage.object.finalize \
-  --trigger-resource <gcs-bucket-name> \
+  --trigger-resource $GCS_BUCKET_NAME \
   --entry-point Google.Cloud.Functions.Examples.FSharpEventFunction.Function
 ```
 
@@ -233,11 +249,12 @@ dotnet new gcf-untyped-event -lang f#
 This function can handle any event type, and logs some generic
 details of the event it receives.
 
-Sample deployment to listen to PubSub events:
+Sample deployment to listen to Pub/Sub events:
 
 ```sh
-gcloud functions deploy fsharp-untyped-event --runtime dotnet3 \
-  --trigger-topic <topic-id> \
+gcloud functions deploy fsharp-untyped-event \
+  --runtime dotnet3 \
+  --trigger-topic $PUBSUB_TOPIC_NAME \
   --entry-point Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.Function
 ```
 
@@ -252,8 +269,10 @@ See the [dependency injection documentation](dependency-injection.md) for more d
 Sample deployment:
 
 ```sh
-gcloud functions deploy simple-dependency-injection --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+gcloud functions deploy simple-dependency-injection \
+  --runtime dotnet3 \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.SimpleDependencyInjection.Function
 ```
 
@@ -269,8 +288,10 @@ See the [dependency injection documentation](dependency-injection.md) for more d
 Sample deployment:
 
 ```sh
-gcloud functions deploy advanced-dependency-injection --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+gcloud functions deploy advanced-dependency-injection \
+  --runtime dotnet3 \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.AdvancedDependencyInjection.Function
 ```
 
@@ -287,8 +308,10 @@ for more details.
 Sample deployment:
 
 ```sh
-gcloud functions deploy time-zone-converter --runtime dotnet3 \
-  --trigger-http --allow-unauthenticated \
+gcloud functions deploy time-zone-converter \
+  --runtime dotnet3 \
+  --trigger-http \
+  --allow-unauthenticated \
   --entry-point Google.Cloud.Functions.Examples.TimeZoneConverter.Function
 ```
 
@@ -306,9 +329,10 @@ for more details.
 Sample deployment:
 
 ```sh
-gcloud functions deploy image-annotator --runtime dotnet3 \
+gcloud functions deploy image-annotator \
+  --runtime dotnet3 \
   --trigger-event google.storage.object.finalize \
-  --trigger-resource <gcs-bucket-name> \
+  --trigger-resource $GCS_BUCKET_NAME \
   --entry-point=Google.Cloud.Functions.Examples.StorageImageAnnotator.Function
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,13 @@
+# Example source code
+
+## Documentation
+
+For information about running these samples, along with a brief
+description of what each example demonstrates, see the
+[examples documentation page](../docs/examples.md).
+
+## Generating
+
 The following projects are the result of creating new projects from
 the templates:
 


### PR DESCRIPTION
- The README.md in examples links to the examples doc page
- The doc page gives generic instructions for running examples
- Each example now has a sample deployment command for GCF

(I'm reluctant to go any further than this, given that there will be
more complete samples on cloud.google.com for beta.)

Fixes #105.