### PR TITLE
Create source URIs as relative-or-absolute

### DIFF
--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             var context = GcfEventResources.CreateHttpContext(resourceName);
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request);
             Assert.Equal(expectedType, cloudEvent.Type);
-            Assert.Equal(new Uri(expectedSource), cloudEvent.Source);
+            Assert.Equal(expectedSource, cloudEvent.Source.ToString());
             Assert.Equal(expectedSubject, cloudEvent.Subject);
         }
 
@@ -54,7 +54,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             Assert.Equal("1147091835525187", cloudEvent.Id);
             Assert.Equal("google.cloud.storage.object.v1.finalized", cloudEvent.Type);
             Assert.Equal(new DateTime(2020, 4, 23, 7, 38, 57, 772), cloudEvent.Time);
-            Assert.Equal(new Uri("//storage.googleapis.com/projects/_/buckets/some-bucket"), cloudEvent.Source);
+            Assert.Equal("//storage.googleapis.com/projects/_/buckets/some-bucket", cloudEvent.Source.ToString());
             Assert.Equal("objects/folder/Test.cs", cloudEvent.Subject);
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Null(cloudEvent.DataSchema);
@@ -68,7 +68,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             string json = "{'data':{}, 'context':{'eventId':'xyz', 'eventType': 'google.pubsub.topic.publish', 'resource':{'service': 'svc', 'name': 'resname'}}}";
             var cloudEvent = await ConvertJson(json);
             Assert.Equal("xyz", cloudEvent.Id);
-            Assert.Equal(new Uri("//svc/resname"), cloudEvent.Source);
+            Assert.Equal("//svc/resname", cloudEvent.Source.ToString());
         }
 
         [Fact]

--- a/src/Google.Cloud.Functions.Framework/GcfEvents/GcfConverters.cs
+++ b/src/Google.Cloud.Functions.Framework/GcfEvents/GcfConverters.cs
@@ -188,7 +188,7 @@ namespace Google.Cloud.Functions.Framework.GcfEvents
 
             protected virtual void MaybeReshapeData(Request request) { }
             protected virtual (Uri source, string? subject) ConvertResourceToSourceAndSubject(string service, string resource) =>
-                (new Uri($"//{service}/{resource}"), null);
+                (new Uri($"//{service}/{resource}", UriKind.RelativeOrAbsolute), null);
         }
 
         private class StorageEventAdapter : EventAdapter
@@ -214,7 +214,7 @@ namespace Google.Cloud.Functions.Framework.GcfEvents
                     resource = match.Groups[1].Value;
                     // Resource name from "objects" onwards, but without the generation
                     var subject = match.Groups[2].Value;
-                    return (new Uri($"//{service}/{resource}"), subject);
+                    return (new Uri($"//{service}/{resource}", UriKind.RelativeOrAbsolute), subject);
                 }
                 // If the resource name didn't match for whatever reason, just use the default behaviour.
                 return base.ConvertResourceToSourceAndSubject(service, resource);


### PR DESCRIPTION
This avoids "//xyz/abc" from being converted to "file://xyz/abc"

Fixes #126