### PR TITLE
Release .NET Functions Framework version 1.0.0-alpha12

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet
 First, install the template package into the .NET tooling:
 
 ```sh
-dotnet new -i Google.Cloud.Functions.Templates::1.0.0-alpha11
+dotnet new -i Google.Cloud.Functions.Templates::1.0.0-alpha12
 ```
 
 Next, create a directory for your project, and use `dotnet new` to

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,31 @@
 # Version History
 
+## 1.0.0-alpha12 (released 2020-09-25)
+
+Just package renaming:
+
+- Old Google.Cloud.Functions.Invoker package is now Google.Cloud.Functions.Hosting
+- Old Google.Cloud.Functions.Invoker.Testing package is now Google.Cloud.Functions.Testing
+
+## 1.0.0-alpha11 (released 2020-09-03)
+
+- Fixed FunctionTestBase.ExecuteCloudEvent
+- Fixed access to logs in nested/generic classes via FunctionTestServer
+
+## 1.0.0-alpha10 (released 2020-09-02)
+
+- Added more convenience methods in FunctionTestBase
+- Format Firestore subject/source as we expect for native CloudEvents
+- Create source URIs for CloudEvents using RelativeOrAbsolute
+
+## 1.0.0-alpha09 (released 2020-08-25)
+
+- Rearchitect [customization](customization.md) and hosting startup
+- Add a FunctionTestBase class to simplify integration testing
+- Suppressed Kestrel heartbeat warnings (which are expected given
+  the "run occasionally" nature of Functions servers)
+- Add public in-memory ILogger implementation for unit testing
+
 ## 1.0.0-alpha08 (released 2020-07-07)
 
 - Added an in-memory logger provider to the test server

--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.RandomValueBase" Version="2.4.4" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-alpha12" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />

--- a/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/CommonProperties.xml
+++ b/src/CommonProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-alpha11</Version>
+    <Version>1.0.0-alpha12</Version>
   </PropertyGroup>
 
   <!-- Build information -->

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha11" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes since 1.0.0-alpha11 are just package renaming:

- Old Google.Cloud.Functions.Invoker package is now Google.Cloud.Functions.Hosting
- Old Google.Cloud.Functions.Invoker.Testing package is now Google.Cloud.Functions.Testing