### PR TITLE
Include Hosting package in Middleware example

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The build.sh script didn't detect the problem because we always
build with LocalFunctionsFramework set to true - which makes sense
in terms of allowing us to write examples for unreleased framework
features, but hides this sort of thing. I think it's a pretty rare
problem - I don't think we need to change the build.