### PR TITLE
docs: Add an example of deploying a multi-project function

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+node_modules
+#!include:.gitignore
+
+# Ignore the submodule
+functions-framework-conformance/

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,3 +102,36 @@ Firestore event          | DocumentEventData     | --trigger-event providers/clo
 >   available in the `FirestoreEvent` class via the `Wildcards` property. This is subject to change,
 >   as it's inconsitent with other Functions Frameworks.
 
+### Deploying a function with a local project dependency
+
+Real world functions are often part of a larger application which
+will usually contain common code for data types and common business
+logic. If your function depends on another project via a local
+project reference (a `<ProjectReference>` element in your .csproj
+file), the source code for that project must also be included when
+deploying to Google Cloud Functions. Additionally, you need to
+specify which project contains the function you wish to deploy.
+
+In a typical directory structure where all projects sit side-by-side
+within one top-level directory, this will mean you need to deploy
+from that top-level directory instead of from the function's project
+directory. You also need to use the `--set-build-env-vars` command
+line flag to specify the `GOOGLE_BUILDABLE` build-time environment
+variable. This tells the Google Cloud Functions deployment process
+which project to build and deploy.
+
+Note that the ability to set build environment variables is
+currently in beta, so you need to use `gcloud beta functions deploy`
+on the command line.
+
+When deploying a function with multiple projects, it's important to
+make sure you have a suitable
+[.gcloudignore](https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore)
+file, so that you only upload the code that you want to. In
+particular, you should almost always include `bin/` and `obj/` in the
+`.gcloudignore` file so that you don't upload your locally-built
+binaries.
+
+See [the multi-project example
+documentation](examples.md#multiprojectfunction-and-multiprojectdependency)
+for a sample deployment command line, as well as sample projects.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -417,6 +417,37 @@ gcloud functions deploy image-annotator \
   --entry-point=Google.Cloud.Functions.Examples.StorageImageAnnotator.Function
 ```
 
+## MultiProjectFunction and MultiProjectDependency
+
+All the other examples provided are standalone, but in real world
+projects, often the project containing your function will depend on
+another local project. The [MultiProjectFunction](../examples/Google.Cloud.Functions.Examples.MultiProjectFunction)
+and [MultiProjectDependency](../examples/Google.Cloud.Functions.Examples.MultiProjectDependency)
+directories provide an example of this: the MultiProjectFunction project depends on the
+MultiProjectDependency project using a `<ProjectReference>` MSBuild element.
+
+When deploying a function that depends on another local project, you
+need to ensure that all the relevant source code is uploaded, and
+that you indicate which project contains the function. See the
+[deployment documentation](deployment.md#deploying-a-function-with-a-local-project-dependency)
+for more details.
+
+Sample deployment, from the `examples` directory:
+
+```sh
+gcloud beta functions deploy multi-project \
+  --runtime dotnet3 \
+  --trigger-http \
+  --entry-point=Google.Cloud.Functions.Examples.MultiProjectFunction.Function
+  --set-build-env-vars=GOOGLE_BUILDABLE=Google.Cloud.Functions.Examples.MultiProjectFunction
+```
+
+This uses the [.gcloudignore
+file in the examples directory](../examples/.gcloudignore) to avoid uploading already-built
+binaries.
+
+Note that the ability to set build environment variables is currently in beta.
+
 ## Integration Tests
 
 The [IntegrationTests](../examples/Google.Cloud.Functions.Examples.IntegrationTests)

--- a/examples/.gcloudignore
+++ b/examples/.gcloudignore
@@ -1,0 +1,8 @@
+# This file tells "gcloud functions deploy" which files and folders
+# to ignore. This is important when deploying multi-project functions,
+# as otherwise a lot of unnecessary files (particularly in the bin and
+# obj directories) may be uploaded.
+
+.gcloudignore
+bin/
+obj/

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -15,7 +15,7 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(LocalFunctionsFramework)' != ''">
+  <ItemGroup Condition="'$(LocalFunctionsFramework)' != '' AND '$(TargetFramework)' == 'netcoreapp3.1'">
     <!-- Even if some projects don't actually need these, it doesn't hurt to have them. -->
     <ProjectReference Include="..\..\src\Google.Cloud.Functions.Hosting\Google.Cloud.Functions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Google.Cloud.Functions.Testing\Google.Cloud.Functions.Testing.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectDependency/BusinessLogic.cs
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectDependency/BusinessLogic.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Functions.Examples.MultiProjectDependency
+{
+    /// <summary>
+    /// See the comments in MultiProjectFunction.Function for the purpose
+    /// of this class.
+    /// </summary>
+    public class BusinessLogic
+    {
+        /// <summary>
+        /// Performs some general business logic which might be needed from multiple
+        /// applications, so belongs in a separate class library.
+        /// </summary>
+        public string PerformGeneralBusinessLogic() => "Profit!";
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectDependency/Google.Cloud.Functions.Examples.MultiProjectDependency.csproj
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectDependency/Google.Cloud.Functions.Examples.MultiProjectDependency.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    
+    <!-- 
+      - This wouldn't be needed in a normal project, but
+      - all examples are optionally built using the local Functions
+      - Framework, and the MSBuild targets are included automatically
+      - for all example projects. We need to disable the generation
+      - of an entry point, as this project isn't a function.
+      -->
+    <AutoGenerateEntryPoint>false</AutoGenerateEntryPoint>
+  </PropertyGroup>
+
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Function.cs
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Function.cs
@@ -1,0 +1,38 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Examples.MultiProjectDependency;
+using Google.Cloud.Functions.Framework;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Examples.MultiProjectFunction
+{
+    /// <summary>
+    /// Function demonstrating how to use a project dependency from the function
+    /// project to a class library. When deploying to Google Cloud Functions, the
+    /// class library code still needs to be uploaded as part of the build, and the
+    /// GOOGLE_BUILDABLE build-time environment variable needs to be set to the
+    /// path to the function project.
+    /// </summary>
+    public class Function : IHttpFunction
+    {
+        public async Task HandleAsync(HttpContext context)
+        {
+            var logic = new BusinessLogic();
+            var result = logic.PerformGeneralBusinessLogic();
+            await context.Response.WriteAsync($"Result: {result}");
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-alpha12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Functions.Examples.MultiProjectDependency\Google.Cloud.Functions.Examples.MultiProjectDependency.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.sln
+++ b/examples/Google.Cloud.Functions.Examples.sln
@@ -43,7 +43,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Exam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.CustomConfiguration", "Google.Cloud.Functions.Examples.CustomConfiguration\Google.Cloud.Functions.Examples.CustomConfiguration.csproj", "{743A84EF-9B19-4E52-9FF1-38DBB54221F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.TestableDependencies", "Google.Cloud.Functions.Examples.TestableDependencies\Google.Cloud.Functions.Examples.TestableDependencies.csproj", "{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.TestableDependencies", "Google.Cloud.Functions.Examples.TestableDependencies\Google.Cloud.Functions.Examples.TestableDependencies.csproj", "{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.MultiProjectDependency", "Google.Cloud.Functions.Examples.MultiProjectDependency\Google.Cloud.Functions.Examples.MultiProjectDependency.csproj", "{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.MultiProjectFunction", "Google.Cloud.Functions.Examples.MultiProjectFunction\Google.Cloud.Functions.Examples.MultiProjectFunction.csproj", "{EE617CF8-2FC4-4A3B-A1F2-11E940644352}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -307,6 +311,30 @@ Global
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x64.Build.0 = Release|Any CPU
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{658EC94D-9A70-4078-8CBD-5FA6CFB0E0EF}.Release|x86.Build.0 = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|x64.Build.0 = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|x64.ActiveCfg = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|x64.Build.0 = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{B20994E9-89A2-4BF9-8CA5-0EAA7B2607DE}.Release|x86.Build.0 = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|x64.Build.0 = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Debug|x86.Build.0 = Debug|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|x64.ActiveCfg = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|x64.Build.0 = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|x86.ActiveCfg = Release|Any CPU
+		{EE617CF8-2FC4-4A3B-A1F2-11E940644352}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Here MultiProjectFunction depends (locally) on
MultiProjectDependency, so both projects must be uploaded together,
and the correct project specified using a build-time environment
variable.