### PR TITLE
Add a test-oriented attribute for functions startups.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,7 +81,7 @@ test frameworks that automatically dispose of test classes. (This
 includes NUnit and xUnit.) The `Dispose` implementation disposes of
 the test server that is owned by the test class.
 
-The parameterless constructor of `FunctionTestbase<TFunction>`
+The parameterless constructor of `FunctionTestBase<TFunction>`
 automatically creates a `FunctionTestServer<TFunction>`, or you can
 pass the test server into the constructor if you want to customize it.
 
@@ -121,6 +121,15 @@ After that, just call the
 the complete set of startup instances, or `null` to use the
 production behavior of using assembly attributes. The method returns
 the same builder it's called on, so you can chain method calls easily.
+
+Alternatively, you can decorate a type with the
+`FunctionTestStartupAttribute` to specify the startup classes to
+use, and call `FunctionTestServerBuilder.MaybeUseFunctionsStartupsFromAttributes`
+to apply the startup classes. This is called automatically in the
+`FunctionTestBase<TFunction>` parameterless constructor, using the
+test class itself - so adding the `FunctionTestStartupAttribute` to
+the test class is the simplest way of configuring startups in those
+tests.
 
 The `FunctionTestServerBuilder.UseFunctionsFrameworkConsoleLogging`
 method can be used to enable console logging in addition to the

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/TestableDependenciesTest.cs
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/TestableDependenciesTest.cs
@@ -21,12 +21,16 @@ using Xunit;
 
 namespace Google.Cloud.Functions.Examples.IntegrationTests
 {
+    /// <summary>
+    /// By default, the test server will use the same Functions Startup classes
+    /// as normal. The TestFunctionStartup attribute specifies Functions Startup classes that
+    /// should be used for this test class, so that it can inject test dependencies instead of the production ones.
+    /// An alternative is to declare a parameterless constructor that creates a FunctionTestServer
+    /// to pass into the base class constructor.
+    /// </summary>
+    [FunctionTestStartup(typeof(TestStartup))]
     public class TestableDependenciesTest : FunctionTestBase<TestableDependencies.Function>
     {
-        public TestableDependenciesTest() : base(CreateServer())
-        {
-        }
-
         [Fact]
         public async Task FunctionOutputDoesNotReferToProduction()
         {
@@ -35,16 +39,8 @@ namespace Google.Cloud.Functions.Examples.IntegrationTests
             Assert.Contains("Test dependency", text);
         }
 
-        /// <summary>
-        /// By default, the test server will use the same Functions Startup classes
-        /// as normal. This method creates a test server that creates a test-oriented Functions Startup
-        /// so that it can inject test dependencies instead of the production ones.
-        /// </summary>
-        private static FunctionTestServer CreateServer() =>
-            FunctionTestServerBuilder.Create<TestableDependencies.Function>()
-                .UseFunctionsStartups(new TestStartup())
-                .Build();
-
+        // Functions Startup class specified in the FunctionTestStartup attribute on the test class,
+        // so that test-only dependencies can be used.
         private class TestStartup : FunctionsStartup
         {
             public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services) =>

--- a/src/Google.Cloud.Functions.Hosting/FunctionsStartupAttribute.cs
+++ b/src/Google.Cloud.Functions.Hosting/FunctionsStartupAttribute.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Functions.Hosting
     public class FunctionsStartupAttribute : Attribute
     {
         /// <summary>
-        /// 
+        /// The Type of the <see cref="FunctionsStartup"/> class to register.
         /// </summary>
         public Type StartupType { get; set; }
 

--- a/src/Google.Cloud.Functions.Testing/FunctionTestBase.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestBase.cs
@@ -56,10 +56,13 @@ namespace Google.Cloud.Functions.Testing
         }
 
         /// <summary>
-        /// Constructs a new instance using a new server constructed with default settings.
+        /// Constructs a new instance using a new server constructed with default settings,
+        /// with startup classes specified by <see cref="FunctionTestStartupAttribute"/> attributes
+        /// within the class hierarchy of the actual test class.
         /// </summary>
-        protected FunctionTestBase() : this(new FunctionTestServer<TFunction>())
+        protected FunctionTestBase()
         {
+            Server = new FunctionTestServer<TFunction>(GetType());
         }
 
         /// <summary>

--- a/src/Google.Cloud.Functions.Testing/FunctionTestServer.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestServer.cs
@@ -122,6 +122,9 @@ namespace Google.Cloud.Functions.Testing
         {
         }
 
+        // Note: it would be nice to make the constructor below public, but that means it can't be used in an
+        // xUnit test fixture via constructor dependency injection.
+
         /// <summary>
         /// Constructs a new instance serving <typeparamref name="TFunction"/>, with an optional
         /// type to inspect for <see cref="FunctionTestStartupAttribute"/> attributes.
@@ -129,7 +132,7 @@ namespace Google.Cloud.Functions.Testing
         /// <param name="attributedStartupType">A type to examine for <see cref="FunctionTestStartupAttribute"/> attributes to provide further customization.
         /// If this is null, or no attributes are specified in the type (or its base class hierarchy) the startup classes in the
         /// function assembly are used.</param>
-        public FunctionTestServer(Type? attributedStartupType) : base(typeof(TFunction), attributedStartupType)
+        internal FunctionTestServer(Type? attributedStartupType) : base(typeof(TFunction), attributedStartupType)
         {
         }
     }

--- a/src/Google.Cloud.Functions.Testing/FunctionTestServer.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestServer.cs
@@ -41,7 +41,20 @@ namespace Google.Cloud.Functions.Testing
         /// Creates a FunctionTestServer for the specified function type.
         /// </summary>
         /// <param name="functionTarget">The function type to host in the server.</param>
-        public FunctionTestServer(Type functionTarget) : this(FunctionTestServerBuilder.Create(functionTarget).BuildTestServer(), functionTarget)
+        public FunctionTestServer(Type functionTarget) : this(functionTarget, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a FunctionTestServer for the specified function type, with an optional
+        /// type to inspect for <see cref="FunctionTestStartupAttribute"/> attributes.
+        /// </summary>
+        /// <param name="functionTarget">The function type to host in the server.</param>
+        /// <param name="attributedStartupType">A type to examine for <see cref="FunctionTestStartupAttribute"/> attributes to provide further customization.
+        /// If this is null, or no attributes are specified in the type (or its base class hierarchy) the startup classes in the
+        /// function assembly are used.</param>
+        public FunctionTestServer(Type functionTarget, Type? attributedStartupType)
+            : this(FunctionTestServerBuilder.Create(functionTarget).MaybeUseFunctionsStartupsFromAttributes(attributedStartupType).BuildTestServer(), functionTarget)
         {
         }
 
@@ -105,7 +118,18 @@ namespace Google.Cloud.Functions.Testing
         /// <summary>
         /// Constructs a new instance serving <typeparamref name="TFunction"/>.
         /// </summary>
-        public FunctionTestServer() : base(typeof(TFunction))
+        public FunctionTestServer() : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance serving <typeparamref name="TFunction"/>, with an optional
+        /// type to inspect for <see cref="FunctionTestStartupAttribute"/> attributes.
+        /// </summary>
+        /// <param name="attributedStartupType">A type to examine for <see cref="FunctionTestStartupAttribute"/> attributes to provide further customization.
+        /// If this is null, or no attributes are specified in the type (or its base class hierarchy) the startup classes in the
+        /// function assembly are used.</param>
+        public FunctionTestServer(Type? attributedStartupType) : base(typeof(TFunction), attributedStartupType)
         {
         }
     }

--- a/src/Google.Cloud.Functions.Testing/FunctionTestStartupAttribute.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestStartupAttribute.cs
@@ -5,7 +5,9 @@ namespace Google.Cloud.Functions.Testing
 {
     /// <summary>
     /// Class attribute to specify a <see cref="FunctionsStartup"/> to use
-    /// for a test server 
+    /// for a test server. These are configured using <see cref="FunctionTestServerBuilder.MaybeUseFunctionsStartupsFromAttributes(Type?)"/>,
+    /// which is automatically called by <see cref="FunctionTestServer{TFunction}"/>, so test classes
+    /// annotated with this attribute automatically use a test server with the specified Functions Startup.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public class FunctionTestStartupAttribute : Attribute

--- a/src/Google.Cloud.Functions.Testing/FunctionTestStartupAttribute.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestStartupAttribute.cs
@@ -1,0 +1,33 @@
+﻿using Google.Cloud.Functions.Hosting;
+using System;
+
+namespace Google.Cloud.Functions.Testing
+{
+    /// <summary>
+    /// Class attribute to specify a <see cref="FunctionsStartup"/> to use
+    /// for a test server 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class FunctionTestStartupAttribute : Attribute
+    {
+        /// <summary>
+        /// The Type of the <see cref="FunctionsStartup"/> class to register.
+        /// </summary>
+        public Type StartupType { get; set; }
+
+        /// <summary>
+        /// The ordering of application of the provider type relative to others
+        /// specified by other attributes. Configurers specified in attributes
+        /// with lower order numbers are invoked before those with higher order numbers.
+        /// Defaults to 0.
+        /// </summary>
+        public int Order { get; set; }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="startupType">The Type of the <see cref="FunctionsStartup"/> class to register.</param>
+        public FunctionTestStartupAttribute(Type startupType) =>
+            StartupType = startupType;
+    }
+}


### PR DESCRIPTION
Fixes #154.

An alternative approach would be to allow the existing
FunctionsStartupAttribute to be applied to types as well as the
assembly... in which case we'd probably want to change the framework
to find startup classes associated with the function itself. That
could potentially be quite useful...

Very happy to discuss those options.