### PR TITLE
Minor F# changes

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
@@ -40,14 +40,18 @@ type Function() =
             printfn "Storage object information:"
             printfn "  Name: %s" data.Name
             printfn "  Bucket: %s" data.Bucket
-            printfn "  Size: %A" data.Size
+            printfn "  Size: %i" data.Size
             printfn "  Content type: %s" data.ContentType
             printfn "Cloud event information:"
             printfn "  ID: %s" cloudEvent.Id
-            printfn "  Source: %A" cloudEvent.Source
+            printfn "  Source: %O" cloudEvent.Source
             printfn "  Type: %s" cloudEvent.Type
             printfn "  Subject: %s" cloudEvent.Subject
-            printfn "  DataSchema: %A" cloudEvent.DataSchema
-            printfn "  DataContentType: %A" cloudEvent.DataContentType
-            printfn "  SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "  DataSchema: %O" cloudEvent.DataSchema
+            printfn "  DataContentType: %O" cloudEvent.DataContentType
+            printfn "  Time: %s" (cloudEvent.Time |> Option.ofNullable |> Option.map(fun time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'") |> Option.defaultValue "")
+            printfn "  SpecVersion: %O" cloudEvent.SpecVersion
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return an arbitrary Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
@@ -49,9 +49,11 @@ type Function() =
             printfn "  Subject: %s" cloudEvent.Subject
             printfn "  DataSchema: %O" cloudEvent.DataSchema
             printfn "  DataContentType: %O" cloudEvent.DataContentType
-            printfn "  Time: %s" (cloudEvent.Time |> Option.ofNullable |> Option.map(fun time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'") |> Option.defaultValue "")
+            printfn "  Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                  | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                  | None -> "")
             printfn "  SpecVersion: %O" cloudEvent.SpecVersion
 
             // In this example, we don't need to perform any asynchronous operations, so we
-            // just return an arbitrary Task to conform to the interface.
+            // just return an completed Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Function.fs
@@ -26,5 +26,5 @@ type Function() =
         /// <returns>A task representing the asynchronous operation.</returns>
         member this.HandleAsync context =
             async {
-                context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask |> ignore
+                do! context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask
             } |> Async.StartAsTask :> _

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
@@ -39,5 +39,5 @@ type Function() =
             printfn "Data: %A" cloudEvent.Data
 
             // In this example, we don't need to perform any asynchronous operations, so we
-            // just return an arbitrary Task to conform to the interface.
+            // just return a completed Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
@@ -33,7 +33,11 @@ type Function() =
             printfn "Type: %s" cloudEvent.Type
             printfn "Subject: %s" cloudEvent.Subject
             printfn "DataSchema: %A" cloudEvent.DataSchema
-            printfn "DataContentType: %A" cloudEvent.DataContentType
-            printfn "SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "DataContentType: %O" cloudEvent.DataContentType
+            printfn "Time: %s" (cloudEvent.Time |> Option.ofNullable |> Option.map(fun time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'") |> Option.defaultValue "")
+            printfn "SpecVersion: %O" cloudEvent.SpecVersion
             printfn "Data: %A" cloudEvent.Data
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return an arbitrary Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
@@ -34,10 +34,14 @@ type Function() =
             printfn "Subject: %s" cloudEvent.Subject
             printfn "DataSchema: %A" cloudEvent.DataSchema
             printfn "DataContentType: %O" cloudEvent.DataContentType
-            printfn "Time: %s" (cloudEvent.Time |> Option.ofNullable |> Option.map(fun time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'") |> Option.defaultValue "")
+            printfn "Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                | None -> "")
             printfn "SpecVersion: %O" cloudEvent.SpecVersion
             printfn "Data: %A" cloudEvent.Data
 
             // In this example, we don't need to perform any asynchronous operations, so we
             // just return a completed Task to conform to the interface.
             Task.CompletedTask
+
+let x = Nullable 10

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
@@ -43,5 +43,3 @@ type Function() =
             // In this example, we don't need to perform any asynchronous operations, so we
             // just return a completed Task to conform to the interface.
             Task.CompletedTask
-
-let x = Nullable 10


### PR DESCRIPTION
Some minor changes to the three F# samples. Hopefully they're useful.

1. The previous use of `async` was semantically incorrect / different from the C# Task version. The current F# example creates the task but never "awaits" it, it just throws it away (with `ignore`) - this is the same as in C# simply not awaiting an async (whereby you get the compiler warning). `do!` is the equivalent to `await` in this context, so I've put that in here.
2. Replace use of %A (which is a kind of magic "print out this value") with either specific modifiers for longs (%i) or ToString (%O).
3. Added the "Time" item which was in the C# examples. F# is a bit (ok, a lot) more verbose here because:
   a. There's no language support for mapping / binding on nullable values, so instead you use `Option.map`.
   b. There's no implicit conversions so we need `Option.ofNullable` to get "into" the Option world.
   c. There's no implicit "default" value, so we explicitly give a default of "" using `Option.defaultValue`