### PR TITLE
Release Functions Framework .NET packages version 1.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet
 First, install the template package into the .NET tooling:
 
 ```sh
-dotnet new -i Google.Cloud.Functions.Templates::1.0.0-beta03
+dotnet new -i Google.Cloud.Functions.Templates::1.0.0-beta04
 ```
 
 Next, create a directory for your project, and use `dotnet new` to

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 1.0.0-beta04 (released 2020-11-19)
+
+- Actually improve the F# templates.
+
+Release 1.0.0-beta03 did not include the new F# templates as
+expected, due to confusion between templates and examples.
+
 ## 1.0.0-beta03 (released 2020-11-19)
 
 - Improvements to F# templates

--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.RandomValueBase" Version="2.4.4" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Function.fs
@@ -40,14 +40,20 @@ type Function() =
             printfn "Storage object information:"
             printfn "  Name: %s" data.Name
             printfn "  Bucket: %s" data.Bucket
-            printfn "  Size: %A" data.Size
+            printfn "  Size: %i" data.Size
             printfn "  Content type: %s" data.ContentType
             printfn "Cloud event information:"
             printfn "  ID: %s" cloudEvent.Id
-            printfn "  Source: %A" cloudEvent.Source
+            printfn "  Source: %O" cloudEvent.Source
             printfn "  Type: %s" cloudEvent.Type
             printfn "  Subject: %s" cloudEvent.Subject
-            printfn "  DataSchema: %A" cloudEvent.DataSchema
-            printfn "  DataContentType: %A" cloudEvent.DataContentType
-            printfn "  SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "  DataSchema: %O" cloudEvent.DataSchema
+            printfn "  DataContentType: %O" cloudEvent.DataContentType
+            printfn "  Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                  | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                  | None -> "")
+            printfn "  SpecVersion: %O" cloudEvent.SpecVersion
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return an completed Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Function.fs
@@ -26,5 +26,5 @@ type Function() =
         /// <returns>A task representing the asynchronous operation.</returns>
         member this.HandleAsync context =
             async {
-                context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask |> ignore
+                do! context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask
             } |> Async.StartAsTask :> _

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Function.fs
@@ -33,7 +33,13 @@ type Function() =
             printfn "Type: %s" cloudEvent.Type
             printfn "Subject: %s" cloudEvent.Subject
             printfn "DataSchema: %A" cloudEvent.DataSchema
-            printfn "DataContentType: %A" cloudEvent.DataContentType
-            printfn "SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "DataContentType: %O" cloudEvent.DataContentType
+            printfn "Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                | None -> "")
+            printfn "SpecVersion: %O" cloudEvent.SpecVersion
             printfn "Data: %A" cloudEvent.Data
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return a completed Task to conform to the interface.
             Task.CompletedTask

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-beta04" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />

--- a/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/CommonProperties.xml
+++ b/src/CommonProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
   </PropertyGroup>
 
   <!-- Build information -->

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/Function.fs
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/Function.fs
@@ -26,14 +26,20 @@ type Function() =
             printfn "Storage object information:"
             printfn "  Name: %s" data.Name
             printfn "  Bucket: %s" data.Bucket
-            printfn "  Size: %A" data.Size
+            printfn "  Size: %i" data.Size
             printfn "  Content type: %s" data.ContentType
             printfn "Cloud event information:"
             printfn "  ID: %s" cloudEvent.Id
-            printfn "  Source: %A" cloudEvent.Source
+            printfn "  Source: %O" cloudEvent.Source
             printfn "  Type: %s" cloudEvent.Type
             printfn "  Subject: %s" cloudEvent.Subject
-            printfn "  DataSchema: %A" cloudEvent.DataSchema
-            printfn "  DataContentType: %A" cloudEvent.DataContentType
-            printfn "  SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "  DataSchema: %O" cloudEvent.DataSchema
+            printfn "  DataContentType: %O" cloudEvent.DataContentType
+            printfn "  Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                  | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                  | None -> "")
+            printfn "  SpecVersion: %O" cloudEvent.SpecVersion
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return an completed Task to conform to the interface.
             Task.CompletedTask

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta02" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/Function.fs
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/Function.fs
@@ -12,5 +12,5 @@ type Function() =
         /// <returns>A task representing the asynchronous operation.</returns>
         member this.HandleAsync context =
             async {
-                context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask |> ignore
+                do! context.Response.WriteAsync "Hello, Functions Framework." |> Async.AwaitTask
             } |> Async.StartAsTask :> _

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/Function.fs
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/Function.fs
@@ -19,7 +19,13 @@ type Function() =
             printfn "Type: %s" cloudEvent.Type
             printfn "Subject: %s" cloudEvent.Subject
             printfn "DataSchema: %A" cloudEvent.DataSchema
-            printfn "DataContentType: %A" cloudEvent.DataContentType
-            printfn "SpecVersion: %A" cloudEvent.SpecVersion
+            printfn "DataContentType: %O" cloudEvent.DataContentType
+            printfn "Time: %s" (match Option.ofNullable cloudEvent.Time with
+                                | Some time -> time.ToUniversalTime().ToString "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+                                | None -> "")
+            printfn "SpecVersion: %O" cloudEvent.SpecVersion
             printfn "Data: %A" cloudEvent.Data
+
+            // In this example, we don't need to perform any asynchronous operations, so we
+            // just return a completed Task to conform to the interface.
             Task.CompletedTask

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes since 1.0.0-beta03:

- Actually improve the F# templates.

Release 1.0.0-beta03 did not include the new F# templates as
expected, due to confusion between templates and examples.

Packages in this release:
- Release Google.Cloud.Functions.Framework version 1.0.0-beta04
- Release Google.Cloud.Functions.Hosting version 1.0.0-beta04
- Release Google.Cloud.Functions.Templates version 1.0.0-beta04
- Release Google.Cloud.Functions.Testing version 1.0.0-beta04