### PR TITLE
Release Functions Framework .NET packages version 1.0.0-beta05

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet
 First, install the template package into the .NET tooling:
 
 ```sh
-dotnet new -i Google.Cloud.Functions.Templates::1.0.0-beta04
+dotnet new -i Google.Cloud.Functions.Templates::1.0.0-beta05
 ```
 
 Next, create a directory for your project, and use `dotnet new` to

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,14 @@
 # Version History
 
+## 1.0.0-beta05 (released 2021-06-07)
+
+- Update to release candidate of CloudNative.CloudEvents package,
+  which removes the need for a Google.Events package at all
+- Minor changes to conversions to CloudEvents (with a few more coming)
+- Dispose of the host instead of the TestServer in FunctionTestServer (fixes #182)
+- Templates now include `appsettings*.json` for deployment (fixes #192 and #201)
+- Add support for scopes (fixes #193)
+
 ## 1.0.0-beta04 (released 2020-11-19)
 
 - Actually improve the F# templates.

--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.RandomValueBase" Version="2.4.4" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.0.0-beta.3" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -11,6 +11,6 @@
   
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.0.0-beta05" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/CommonProperties.xml
+++ b/src/CommonProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
   </PropertyGroup>
 
   <!-- Build information -->

--- a/src/Google.Cloud.Functions.ConformanceTests/UntypedCloudEventFunction.cs
+++ b/src/Google.Cloud.Functions.ConformanceTests/UntypedCloudEventFunction.cs
@@ -27,6 +27,6 @@ public class UntypedCloudEventFunction : ICloudEventFunction
         // Write out a structured JSON representation of the CloudEvent
         var formatter = new JsonEventFormatter();
         var bytes = formatter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
-        await File.WriteAllBytesAsync("function_output.json", bytes);
+        await File.WriteAllBytesAsync("function_output.json", bytes.ToArray());
     }
 }

--- a/src/Google.Cloud.Functions.Framework.Tests/Google.Cloud.Functions.Framework.Tests.csproj
+++ b/src/Google.Cloud.Functions.Framework.Tests/Google.Cloud.Functions.Framework.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Google.Cloud.Functions.Framework/Google.Cloud.Functions.Framework.csproj
+++ b/src/Google.Cloud.Functions.Framework/Google.Cloud.Functions.Framework.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.0.0-beta.3" />
+    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Hosting.Tests/Google.Cloud.Functions.Hosting.Tests.csproj
+++ b/src/Google.Cloud.Functions.Hosting.Tests/Google.Cloud.Functions.Hosting.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Functions.Hosting\Google.Cloud.Functions.Hosting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Testing\Google.Cloud.Functions.Testing.csproj" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Google.Cloud.Functions.Hosting.Tests/Google.Cloud.Functions.Hosting.Tests.csproj
+++ b/src/Google.Cloud.Functions.Hosting.Tests/Google.Cloud.Functions.Hosting.Tests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Google.Cloud.Functions.Hosting\Google.Cloud.Functions.Hosting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Testing\Google.Cloud.Functions.Testing.csproj" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
+++ b/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj" />
     <!-- TODO: Replace this with System.Text.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0-beta.3" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
+++ b/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
@@ -10,8 +10,6 @@
   <ItemGroup>
     <Content Include="targets/*" PackagePath="build/$(TargetFramework)/" />
     <ProjectReference Include="..\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj" />
-    <!-- TODO: Replace this with System.Text.Json -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -11,6 +11,6 @@
   
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0-beta05" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Testing.Tests/Google.Cloud.Functions.Testing.Tests.csproj
+++ b/src/Google.Cloud.Functions.Testing.Tests/Google.Cloud.Functions.Testing.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Functions.Testing\Google.Cloud.Functions.Testing.csproj" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta04" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-beta05" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Google.Cloud.Functions.Testing/FunctionTestBase.cs
+++ b/src/Google.Cloud.Functions.Testing/FunctionTestBase.cs
@@ -118,7 +118,7 @@ namespace Google.Cloud.Functions.Testing
                 // Any URI 
                 RequestUri = new Uri("uri", UriKind.Relative),
                 // CloudEvent headers
-                Content = new ByteArrayContent(bytes) { Headers = { ContentType = mediaContentType } },
+                Content = new ReadOnlyMemoryContent(bytes) { Headers = { ContentType = mediaContentType } },
                 Method = HttpMethod.Post
             };
 


### PR DESCRIPTION
Changes since 1.0.0-beta04:

- Update to release candidate of CloudNative.CloudEvents package,
  which removes the need for a Google.Events package at all
- Minor changes to conversions to CloudEvents (with a few more coming)
- Dispose of the host instead of the TestServer in FunctionTestServer (fixes #182)
- Templates now include `appsettings*.json` for deployment (fixes #192 and #201)
- Add support for scopes (fixes #193)

Packages in this release:
- Release Google.Cloud.Functions.Framework version 1.0.0-beta05
- Release Google.Cloud.Functions.Hosting version 1.0.0-beta05
- Release Google.Cloud.Functions.Templates version 1.0.0-beta05
- Release Google.Cloud.Functions.Testing version 1.0.0-beta05