### PR TITLE
Remove version number from template installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet
 First, install the template package into the .NET tooling:
 
 ```sh
-dotnet new -i Google.Cloud.Functions.Templates::1.0.0
+dotnet new -i Google.Cloud.Functions.Templates
 ```
 
 Next, create a directory for your project, and use `dotnet new` to


### PR DESCRIPTION
(It's not needed now that the package has hit 1.0.0.)