### PR TITLE
Update CloudEvents SDK dependencies

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
-    <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.0.0" />
+    <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.1.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Framework.Tests/CloudEventAdapterTDataTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/CloudEventAdapterTDataTest.cs
@@ -120,6 +120,6 @@ namespace Google.Cloud.Functions.Framework.Tests
         }
 
         private static CloudEventAdapter<TData> CreateAdapter<TData>(ICloudEventFunction<TData> function) where TData : class =>
-            new CloudEventAdapter<TData>(function, CloudEventFormatterAttribute.CreateFormatter(typeof(TData)), new NullLogger<CloudEventAdapter<TData>>());
+            new CloudEventAdapter<TData>(function, CloudEventFormatterAttribute.CreateFormatter(typeof(TData))!, new NullLogger<CloudEventAdapter<TData>>());
     }
 }

--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/EventDeserializationTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/EventDeserializationTest.cs
@@ -221,7 +221,8 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T))
                 ?? throw new InvalidOperationException("No formatter available");
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, formatter);
-            return (T) cloudEvent.Data;
+            // We know that ConvertGcfEventToCloudEvent always populates the Data property.
+            return (T) cloudEvent.Data!;
         }
     }
 }

--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/GcfConvertersTest.cs
@@ -48,7 +48,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             var context = GcfEventResources.CreateHttpContext(resourceName);
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, s_jsonFormatter);
             Assert.Equal(expectedType, cloudEvent.Type);
-            Assert.Equal(expectedSource, cloudEvent.Source.ToString());
+            Assert.Equal(expectedSource, cloudEvent.Source?.ToString());
             Assert.Equal(expectedSubject, cloudEvent.Subject);
         }
 
@@ -61,7 +61,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
         {
             var context = GcfEventResources.CreateHttpContext(resourceName);
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, s_jsonFormatter);
-            var attributeValue = (string) cloudEvent[extensionAttributeName];
+            var attributeValue = (string) cloudEvent[extensionAttributeName]!;
             Assert.Equal(expectedValue, attributeValue);
         }
 
@@ -72,7 +72,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
         {
             var context = GcfEventResources.CreateHttpContext(resourceName);
             var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, s_jsonFormatter);
-            var data = (JsonElement) cloudEvent.Data;
+            var data = (JsonElement) cloudEvent.Data!;
             var actualPublishTime = data.GetProperty("message").GetProperty("publishTime").GetString();
             Assert.Equal(expectedPublishTime, actualPublishTime);
         }
@@ -87,7 +87,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             Assert.Equal("1147091835525187", cloudEvent.Id);
             Assert.Equal("google.cloud.storage.object.v1.finalized", cloudEvent.Type);
             Assert.Equal(new DateTimeOffset(2020, 4, 23, 7, 38, 57, 772, TimeSpan.Zero), cloudEvent.Time);
-            Assert.Equal("//storage.googleapis.com/projects/_/buckets/some-bucket", cloudEvent.Source.ToString());
+            Assert.Equal("//storage.googleapis.com/projects/_/buckets/some-bucket", cloudEvent.Source?.ToString());
             Assert.Equal("objects/folder/Test.cs", cloudEvent.Subject);
             Assert.Equal(CloudEventsSpecVersion.V1_0, cloudEvent.SpecVersion);
             Assert.Equal("some-bucket", cloudEvent["bucket"]);
@@ -102,7 +102,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             string json = "{'data':{}, 'context':{'eventId':'xyz', 'eventType': 'google.pubsub.topic.publish', 'resource':{'service': 'svc', 'name': 'resname'}}}";
             var cloudEvent = await ConvertJson(json);
             Assert.Equal("xyz", cloudEvent.Id);
-            Assert.Equal("//svc/resname", cloudEvent.Source.ToString());
+            Assert.Equal("//svc/resname", cloudEvent.Source?.ToString());
         }
 
         [Fact]

--- a/src/Google.Cloud.Functions.Framework/CloudEventAdapterTData.cs
+++ b/src/Google.Cloud.Functions.Framework/CloudEventAdapterTData.cs
@@ -64,7 +64,7 @@ namespace Google.Cloud.Functions.Framework
             try
             {
                 cloudEvent = await CloudEventAdapter.ConvertRequestAsync(context.Request, _formatter);
-                data = (TData) cloudEvent.Data;
+                data = (TData) cloudEvent.Data!;
             }
             catch (Exception e)
             {

--- a/src/Google.Cloud.Functions.Framework/Google.Cloud.Functions.Framework.csproj
+++ b/src/Google.Cloud.Functions.Framework/Google.Cloud.Functions.Framework.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
+++ b/src/Google.Cloud.Functions.Hosting/Google.Cloud.Functions.Hosting.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Content Include="targets/*" PackagePath="build/$(TargetFramework)/" />
     <ProjectReference Include="..\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj" />
-    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The code changes are to handle the nullable reference types which
are now in the SDK. The Functions Framework itself still doesn't
advertise anything around nullable reference types - that's a change
that *could* come later if we want to.