### PR TITLE
docs: Add missing backslash to sample deployment command line

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -466,7 +466,7 @@ Sample deployment, from the `examples` directory:
 gcloud functions deploy multi-project \
   --runtime dotnet3 \
   --trigger-http \
-  --entry-point=Google.Cloud.Functions.Examples.MultiProjectFunction.Function
+  --entry-point=Google.Cloud.Functions.Examples.MultiProjectFunction.Function \
   --set-build-env-vars=GOOGLE_BUILDABLE=Google.Cloud.Functions.Examples.MultiProjectFunction
 ```
 


### PR DESCRIPTION
(Discovered while answering a Stack Overflow question...)