### PR TITLE
docs: update broken badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Functions Framework for .NET
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FGoogleCloudPlatform%2Ffunctions-framework-dotnet%2Fbadge&style=flat)](https://actions-badge.atrox.dev/GoogleCloudPlatform/functions-framework-dotnet/goto)
+[![.NET Unit CI](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/unit.yml/badge.svg)](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/unit.yml)
+[![.NET Lint CI](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/lint.yml/badge.svg)](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/lint.yml)
+[![.NET Conformance CI](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/conformance.yml/badge.svg)](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/actions/workflows/conformance.yml)
 
 [![Google.Cloud.Functions.Framework](https://img.shields.io/nuget/vpre/Google.Cloud.Functions.Framework?label=Google.Cloud.Functions.Framework)](https://nuget.org/packages/Google.Cloud.Functions.Framework)
-
 [![Google.Cloud.Functions.Hosting](https://img.shields.io/nuget/vpre/Google.Cloud.Functions.Hosting?label=Google.Cloud.Functions.Hosting)](https://nuget.org/packages/Google.Cloud.Functions.Hosting)
-
 [![Google.Cloud.Functions.Templates](https://img.shields.io/nuget/vpre/Google.Cloud.Functions.Templates?label=Google.Cloud.Functions.Templates)](https://nuget.org/packages/Google.Cloud.Functions.Templates)
-
 [![Google.Cloud.Functions.Testing](https://img.shields.io/nuget/vpre/Google.Cloud.Functions.Testing?label=Google.Cloud.Functions.Testing)](https://nuget.org/packages/Google.Cloud.Functions.Testing)
 
 An open source FaaS (Function as a service) framework for writing portable


### PR DESCRIPTION
Replaces README badges. GitHub Actions has native badges and badge.atrox.dev is broken.

Feel free to say the formatting should be different.