### PR TITLE
docs: Demo of a PubSub "proxy" function for local development.

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.PubSubEmulatorDemo/Google.Cloud.Functions.Examples.PubSubEmulatorDemo.csproj
+++ b/examples/Google.Cloud.Functions.Examples.PubSubEmulatorDemo/Google.Cloud.Functions.Examples.PubSubEmulatorDemo.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.PubSub.V1" Version="2.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.PubSubEmulatorDemo/Program.cs
+++ b/examples/Google.Cloud.Functions.Examples.PubSubEmulatorDemo/Program.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2021, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf;
+using System;
+using System.Threading;
+
+namespace Google.Cloud.Functions.Examples.PubSubEmulatorDemo
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                Console.WriteLine("Expected arguments: <topic-name> <push-url> <message count>");
+                return;
+            }
+
+            string topicName = args[0];
+            string pushUrl = args[1];
+            int messageCount = int.Parse(args[2]);
+
+            // Create the clients.
+            var publisherClient = new PublisherServiceApiClientBuilder
+            {
+                EmulatorDetection = EmulatorDetection.EmulatorOnly
+            }.Build();
+
+            var subscriberClient = new SubscriberServiceApiClientBuilder
+            {
+                EmulatorDetection = EmulatorDetection.EmulatorOnly
+            }.Build();
+
+            // Create the topic and subscription.
+            var topic = publisherClient.CreateTopic(topicName);
+            var subscription = new Subscription
+            {
+                TopicAsTopicName = topic.TopicName,
+                PushConfig = new PushConfig { PushEndpoint = pushUrl }
+            };
+            subscriberClient.CreateSubscription(subscription);
+
+            // Publish the messages, one per batch, waiting a second between each message.
+            for (int i = 0; i < messageCount; i++)
+            {
+                var batch = new[]
+                {
+                    new PubsubMessage { Data = ByteString.CopyFromUtf8($"Message {i}") }
+                };
+                publisherClient.Publish(topic.TopicName, batch);
+                Thread.Sleep(1000);
+            }
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.PubSubFunction/Function.cs
+++ b/examples/Google.Cloud.Functions.Examples.PubSubFunction/Function.cs
@@ -1,0 +1,28 @@
+using CloudNative.CloudEvents;
+using Google.Cloud.Functions.Framework;
+using Google.Events.Protobuf.Cloud.PubSub.V1;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Examples.PubSubFunction
+{
+    /// <summary>
+    /// A function that receives PubSub messages and logs them.
+    /// </summary>
+    public class Function : ICloudEventFunction<MessagePublishedData>
+    {
+        private readonly ILogger _logger;
+
+        public Function(ILogger<Function> logger) => _logger = logger;
+
+        public Task HandleAsync(CloudEvent cloudEvent, MessagePublishedData data, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Received message ID {id} with text '{text}'", data.Message.MessageId, data.Message.TextData);
+
+            // In this example, we don't need to perform any asynchronous operations, so the
+            // method doesn't need to be declared async.
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.PubSubFunction/Google.Cloud.Functions.Examples.PubSubFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.PubSubFunction/Google.Cloud.Functions.Examples.PubSubFunction.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
+    <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/Function.cs
+++ b/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/Function.cs
@@ -1,0 +1,89 @@
+﻿// Copyright 2021, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using CloudNative.CloudEvents.Core;
+using CloudNative.CloudEvents.Http;
+using Google.Cloud.Functions.Framework;
+using Google.Cloud.Functions.Hosting;
+using Google.Events.Protobuf;
+using Google.Events.Protobuf.Cloud.PubSub.V1;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Functions.Examples.PubSubPushProxy
+{
+    public class PubSubFunctionOptions
+    {
+        public const string ConfigurationSection = "PubSubFunction";
+
+        public string Url { get; set; }
+    }
+
+    public class Startup : FunctionsStartup
+    {
+        public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
+        {
+            PubSubFunctionOptions options = new PubSubFunctionOptions();
+            context.Configuration
+                .GetSection(PubSubFunctionOptions.ConfigurationSection)
+                .Bind(options);
+
+            services.AddSingleton(options).AddHttpClient();
+        }
+    }
+
+    [FunctionsStartup(typeof(Startup))]
+    public class Function : IHttpFunction
+    {
+        private static readonly CloudEventFormatter s_formatter = new ProtobufJsonCloudEventFormatter<MessagePublishedData>();
+        private readonly PubSubFunctionOptions _options;
+        private readonly ILogger _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public Function(PubSubFunctionOptions options, ILogger<Function> logger, IHttpClientFactory client) =>
+            (_options, _logger, _httpClientFactory) = (options, logger, client);
+
+        public async Task HandleAsync(HttpContext context)
+        {
+            // Parse the incoming request. The body is actually the same as we'd use for a
+            // binary mode CloudEvent, but parsing it allows us to set appropriate CloudEvent attributes.
+            var memory = await BinaryDataUtilities.ToReadOnlyMemoryAsync(context.Request.Body);
+            var cloudEvent = new CloudEvent();
+            s_formatter.DecodeBinaryModeEventData(memory, cloudEvent);
+
+            var data = (MessagePublishedData) cloudEvent.Data;
+            cloudEvent.Id = data.Message.MessageId;
+            cloudEvent.DataContentType = "application/json";
+            // TODO: the source should actually be the topic, not the subscription. It's unclear whether that's available though.
+            // We could potentially configure it in PubSubFunctionOptions. We should also populate the "topic" CloudEvent
+            // attribute to replicate Eventarc behavior.
+            cloudEvent.Source = new Uri($"//pubsub.googleapis.com/{data.Subscription}", UriKind.RelativeOrAbsolute);
+            cloudEvent.Type = MessagePublishedData.MessagePublishedCloudEventType;
+            cloudEvent.Time = DateTimeOffset.UtcNow;
+
+            _logger.LogInformation("Proxying message ID {id} to {url}", data.Message.MessageId, _options.Url);
+
+            var client = _httpClientFactory.CreateClient();
+            // Now send a fully-valid CloudEvent request to the real function.
+            await client.PostAsync(_options.Url, cloudEvent.ToHttpContent(ContentMode.Binary, s_formatter));
+        }
+    }
+}

--- a/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/Google.Cloud.Functions.Examples.PubSubPushProxy.csproj
+++ b/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/Google.Cloud.Functions.Examples.PubSubPushProxy.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
+    <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/appsettings.json
+++ b/examples/Google.Cloud.Functions.Examples.PubSubPushProxy/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "PubSubFunction": {
+    "Url": "http://localhost:8080"
+  }
+}

--- a/examples/Google.Cloud.Functions.Examples.sln
+++ b/examples/Google.Cloud.Functions.Examples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29920.165
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Framework", "..\src\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj", "{BC5628D6-6C14-4A7B-888C-6AFAED08A187}"
 EndProject
@@ -50,6 +50,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.MultiProjectFunction", "Google.Cloud.Functions.Examples.MultiProjectFunction\Google.Cloud.Functions.Examples.MultiProjectFunction.csproj", "{EE617CF8-2FC4-4A3B-A1F2-11E940644352}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Functions.Examples.CustomEventDataFunction", "Google.Cloud.Functions.Examples.CustomEventDataFunction\Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj", "{2A82A319-CEDB-4CF4-8EB4-25DD5CCFE0C6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.PubSubPushProxy", "Google.Cloud.Functions.Examples.PubSubPushProxy\Google.Cloud.Functions.Examples.PubSubPushProxy.csproj", "{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.PubSubEmulatorDemo", "Google.Cloud.Functions.Examples.PubSubEmulatorDemo\Google.Cloud.Functions.Examples.PubSubEmulatorDemo.csproj", "{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Functions.Examples.PubSubFunction", "Google.Cloud.Functions.Examples.PubSubFunction\Google.Cloud.Functions.Examples.PubSubFunction.csproj", "{93653EA1-B98E-41A1-842C-FACDB442ADE6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -349,6 +355,42 @@ Global
 		{2A82A319-CEDB-4CF4-8EB4-25DD5CCFE0C6}.Release|x64.Build.0 = Release|Any CPU
 		{2A82A319-CEDB-4CF4-8EB4-25DD5CCFE0C6}.Release|x86.ActiveCfg = Release|Any CPU
 		{2A82A319-CEDB-4CF4-8EB4-25DD5CCFE0C6}.Release|x86.Build.0 = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|x64.Build.0 = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Debug|x86.Build.0 = Debug|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|x64.ActiveCfg = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|x64.Build.0 = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|x86.ActiveCfg = Release|Any CPU
+		{6D4B8591-A148-4458-AEAB-28AC7ABB8F52}.Release|x86.Build.0 = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|x64.Build.0 = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Debug|x86.Build.0 = Debug|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|x64.ActiveCfg = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|x64.Build.0 = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|x86.ActiveCfg = Release|Any CPU
+		{8C16EAC5-28F4-4FA7-9ADB-F42719E80257}.Release|x86.Build.0 = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|x64.Build.0 = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Debug|x86.Build.0 = Debug|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|x64.ActiveCfg = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|x64.Build.0 = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|x86.ActiveCfg = Release|Any CPU
+		{93653EA1-B98E-41A1-842C-FACDB442ADE6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is an HTTP function which is configured to make requests to a
CloudEvent PubSub function. It is designed to receive requests from
the PubSub emulator (via a subscription with a push config),
allowing for local development where normally an application would
publish PubSub messages and a CloudEvent function would consume them.