### PR TITLE
feat: Warn if the "unknown topic" resource name is used

### DIFF
--- a/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/EventDeserializationTest.cs
+++ b/src/Google.Cloud.Functions.Framework.Tests/GcfEvents/EventDeserializationTest.cs
@@ -22,6 +22,7 @@ using Google.Events.Protobuf.Firebase.Auth.V1;
 using Google.Events.Protobuf.Firebase.Database.V1;
 using Google.Protobuf.WellKnownTypes;
 using Google.Type;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -246,7 +247,7 @@ namespace Google.Cloud.Functions.Framework.Tests.GcfEvents
             var context = GcfEventResources.CreateHttpContext(resourceName, path);
             var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(T))
                 ?? throw new InvalidOperationException("No formatter available");
-            var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, formatter);
+            var cloudEvent = await GcfConverters.ConvertGcfEventToCloudEvent(context.Request, formatter, NullLogger.Instance);
             // We know that ConvertGcfEventToCloudEvent always populates the Data property.
             return (T) cloudEvent.Data!;
         }

--- a/src/Google.Cloud.Functions.Framework.Tests/Google.Cloud.Functions.Framework.Tests.csproj
+++ b/src/Google.Cloud.Functions.Framework.Tests/Google.Cloud.Functions.Framework.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Functions.Framework\Google.Cloud.Functions.Framework.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Functions.Testing\Google.Cloud.Functions.Testing.csproj" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Google.Cloud.Functions.Framework/CloudEventAdapter.cs
+++ b/src/Google.Cloud.Functions.Framework/CloudEventAdapter.cs
@@ -57,7 +57,7 @@ namespace Google.Cloud.Functions.Framework
 
             try
             {
-                cloudEvent = await ConvertRequestAsync(context.Request, _formatter);
+                cloudEvent = await ConvertRequestAsync(context.Request, _formatter, _logger);
             }
             catch (Exception e)
             {
@@ -74,10 +74,11 @@ namespace Google.Cloud.Functions.Framework
         /// </summary>
         /// <param name="request">The request to convert.</param>
         /// <param name="formatter">The formatter to use for conversion.</param>
+        /// <param name="logger">The logger to use to report any warnings.</param>
         /// <returns>A valid CloudEvent</returns>
-        internal static Task<CloudEvent> ConvertRequestAsync(HttpRequest request, CloudEventFormatter formatter) =>
+        internal static Task<CloudEvent> ConvertRequestAsync(HttpRequest request, CloudEventFormatter formatter, ILogger logger) =>
             request.IsCloudEvent()
             ? request.ToCloudEventAsync(formatter)
-            : GcfConverters.ConvertGcfEventToCloudEvent(request, formatter);
+            : GcfConverters.ConvertGcfEventToCloudEvent(request, formatter, logger);
     }
 }

--- a/src/Google.Cloud.Functions.Framework/CloudEventAdapterTData.cs
+++ b/src/Google.Cloud.Functions.Framework/CloudEventAdapterTData.cs
@@ -63,7 +63,7 @@ namespace Google.Cloud.Functions.Framework
             TData data;
             try
             {
-                cloudEvent = await CloudEventAdapter.ConvertRequestAsync(context.Request, _formatter);
+                cloudEvent = await CloudEventAdapter.ConvertRequestAsync(context.Request, _formatter, _logger);
                 data = (TData) cloudEvent.Data!;
             }
             catch (Exception e)


### PR DESCRIPTION
Closes #239 (in conjunction with a discussion of Functions Frameworks owners)

Currently we warn on every request. Warning only once would be
feasible, but only globally, which isn't ideal.