### PR TITLE
chore: enable concurrency conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.15.2'
+        go-version: '^1.16'
         
     - name: Clear NuGet cache
       run: dotnet nuget locals all --clear

--- a/run-conformance-tests.sh
+++ b/run-conformance-tests.sh
@@ -68,18 +68,21 @@ echo "Using Functions Framework test binary: $DOTNET_DLL"
 run_test() {
   TEST_TYPE=$1
   TEST_FUNCTION=$2
+  EXTRA_ARGS=$3
   echo "Running '$TEST_TYPE' test with function '$TEST_FUNCTION'"
   (cd tmp/conformance-test-output && \
-   mkdir $TEST_TYPE && \
-   cd $TEST_TYPE && \
+   mkdir $TEST_FUNCTION && \
+   cd $TEST_FUNCTION && \
    ../../../$CLIENT_BINARY \
      -buildpacks=false \
      -type=$TEST_TYPE \
      -cmd="dotnet ../../../$DOTNET_DLL $TEST_FUNCTION" \
+     $EXTRA_ARGS
   )
 }
 
 run_test http HttpFunction
 run_test cloudevent UntypedCloudEventFunction
+run_test http ConcurrentHttpFunction -validate-concurrency=true
 
 echo "Tests completed successfully"

--- a/src/Google.Cloud.Functions.ConformanceTests/ConcurrentHttpFunction.cs
+++ b/src/Google.Cloud.Functions.ConformanceTests/ConcurrentHttpFunction.cs
@@ -20,8 +20,5 @@ using System.Threading.Tasks;
 // Note: no namespace, to make it simpler to run as part of conformance testing
 public class ConcurrentHttpFunction : IHttpFunction
 {
-    public async Task HandleAsync(HttpContext context)
-    {
-        await Task.Delay(1000);
-    }
+    public Task HandleAsync(HttpContext context) => Task.Delay(1000);
 }

--- a/src/Google.Cloud.Functions.ConformanceTests/ConcurrentHttpFunction.cs
+++ b/src/Google.Cloud.Functions.ConformanceTests/ConcurrentHttpFunction.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2022, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Framework;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using System.Threading.Tasks;
+
+// Note: no namespace, to make it simpler to run as part of conformance testing
+public class ConcurrentHttpFunction : IHttpFunction
+{
+    public async Task HandleAsync(HttpContext context)
+    {
+        await Task.Delay(1000);
+    }
+}


### PR DESCRIPTION
Tests that the framework can handle 10 requests to a function that
sleeps for 1s in about 1s.