### PR TITLE
chore: Revert .NET SDK version changes

### DIFF
--- a/.github/workflows/buildpack-integration-test.yaml
+++ b/.github/workflows/buildpack-integration-test.yaml
@@ -7,38 +7,24 @@ on:
   workflow_dispatch:
 jobs:
   dotnet3:
-    runs-on: ubuntu-latest    
-  
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '3.1.x'
-    
-    - name: Run buildpack integration test
-      uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
-      with:
-        # This builds a local copy of the Functions Framework, and creates
-        # a standalone copy of the conformance test function in tmp
-        # with a NuGet config file to use the local FF.
-        prerun: 'src/Google.Cloud.Functions.ConformanceTests/create-standalone.sh'
-        http-builder-source: 'tmp/Google.Cloud.Functions.ConformanceTests'
-        http-builder-target: 'HttpFunction'
-        cloudevent-builder-source: 'tmp/Google.Cloud.Functions.ConformanceTests'
-        cloudevent-builder-target: 'UntypedCloudEventFunction'
-        builder-runtime: 'dotnet3'
-        # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/dotnet3/builder
-        builder-tag: 'dotnet3_20220516_3_1_416_RC00'
-        # Ask the test runner to wait for 5 seconds for the server to start
-        # before sending it requests. It should come up much quicker
-        # than that, but 5 seconds will rule out "slow startup" as
-        # a failure mode.
-        start-delay: 5
-        # The conformance function writes to the current directory, which will be
-        # /workspace/bin when run from the buildpack.
-        output-file: bin/function_output.json
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    with:
+      # This builds a local copy of the Functions Framework, and creates
+      # a standalone copy of the conformance test function in tmp
+      # with a NuGet config file to use the local FF.
+      prerun: 'src/Google.Cloud.Functions.ConformanceTests/create-standalone.sh'
+      http-builder-source: 'tmp/Google.Cloud.Functions.ConformanceTests'
+      http-builder-target: 'HttpFunction'
+      cloudevent-builder-source: 'tmp/Google.Cloud.Functions.ConformanceTests'
+      cloudevent-builder-target: 'UntypedCloudEventFunction'
+      builder-runtime: 'dotnet3'
+      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/dotnet3/builder
+      builder-tag: 'dotnet3_20220516_3_1_416_RC00'
+      # Ask the test runner to wait for 5 seconds for the server to start
+      # before sending it requests. It should come up much quicker
+      # than that, but 5 seconds will rule out "slow startup" as
+      # a failure mode.
+      start-delay: 5
+      # The conformance function writes to the current directory, which will be
+      # /workspace/bin when run from the buildpack.
+      output-file: bin/function_output.json

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.424",
+    "version": "3.1.100",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
We need to work out how to get the latest version of the SDK when running the buildpack integration test