### PR TITLE
build: enable release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+manifest: true
+handleGHRelease: true

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,1 @@
+enabled: true

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "src/Google.Cloud.Functions.Framework": "1.0.0",
+  "src/Google.Cloud.Functions.Hosting": "1.0.0",
+  "src/Google.Cloud.Functions.Templates": "1.0.0",
+  "src/Google.Cloud.Functions.Testing": "1.0.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "include-component-in-tag": true,
+  "include-v-in-tag": false,
+  "changelog-path": "docs/history.md",
+  "packages": {
+    "src/Google.Cloud.Functions.Framework": {
+      "component": "Google.Cloud.Functions.Framework",
+      "changelog-path": "/docs/history.md",
+      "extra-files": [
+        {
+          "type": "xml",
+          "path": "/src/CommonProperties.xml",
+          "xpath": "//Project/PropertyGroup/Version"
+        }
+      ]
+    },
+    "src/Google.Cloud.Functions.Hosting": {
+      "component": "Google.Cloud.Functions.Hosting"
+    },
+    "src/Google.Cloud.Functions.Templates": {
+      "component": "Google.Cloud.Functions.Templates"
+    },
+    "src/Google.Cloud.Functions.Testing": {
+      "component": "Google.Cloud.Functions.Testing"
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "Google.Cloud.Functions",
+      "components": [
+        "Google.Cloud.Functions.Framework",
+        "Google.Cloud.Functions.Hosting",
+        "Google.Cloud.Functions.Templates",
+        "Google.Cloud.Functions.Testing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The enables release-please while only updating the `src/CommonProperties.xml` file. Post-processing should update the remaining files.

This an example PR created from the above config: https://github.com/GoogleCloudPlatform/functions-framework-dotnet/pull/269