### PR TITLE
chore: Update buildpack integration test to use latest tag implicitly

### DIFF
--- a/.github/workflows/buildpack-integration-test.yaml
+++ b/.github/workflows/buildpack-integration-test.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   dotnet3:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.7.0
     with:
       # This builds a local copy of the Functions Framework, and creates
       # a standalone copy of the conformance test function in tmp
@@ -17,9 +17,7 @@ jobs:
       http-builder-target: 'HttpFunction'
       cloudevent-builder-source: 'tmp/Google.Cloud.Functions.ConformanceTests'
       cloudevent-builder-target: 'UntypedCloudEventFunction'
-      builder-runtime: 'dotnet3'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/dotnet3/builder
-      builder-tag: 'dotnet3_20220516_3_1_416_RC00'
+      builder-runtime: 'dotnet'
       # Ask the test runner to wait for 5 seconds for the server to start
       # before sending it requests. It should come up much quicker
       # than that, but 5 seconds will rule out "slow startup" as


### PR DESCRIPTION
Using the "dotnet" builder should work for both dotnet3 and dotnet6.