### PR TITLE
chore: Update packaging to use PackageLicenseExpression

### DIFF
--- a/src/CommonProperties.xml
+++ b/src/CommonProperties.xml
@@ -29,7 +29,7 @@
     <!-- TODO: Find a Functions-specific icon URL. -->
     <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
     <PackageIcon>NuGetIcon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/functions-framework-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/functions-framework-dotnet</RepositoryUrl>


### PR DESCRIPTION
We still include the license file within the package, so we continue to meet all obligations, but this is easier for customers to validate.

(Non-urgent to review.)