### PR TITLE
tests: Fix buildpack integration tests

### DIFF
--- a/src/Google.Cloud.Functions.ConformanceTests/create-standalone.sh
+++ b/src/Google.Cloud.Functions.ConformanceTests/create-standalone.sh
@@ -32,6 +32,9 @@ rm -rf $TMP_TESTS/bin
 rm -rf $TMP_TESTS/obj
 mkdir $TMP_TESTS/nupkg
 
+# For these conformance tests, use whatever .NET SDK is already present.
+rm $REPO_ROOT/global.json
+
 dotnet pack $REPO_ROOT/src \
   -o $TMP_TESTS/nupkg \
   -p:Version=999.0.0


### PR DESCRIPTION
We need to build the code with whatever .NET SDK is installed in the buildpack. We shouldn't force that to be the same SDK that the Functions Framework itself uses for its normal build.