### PR TITLE
chore: add missing endpoints to policy

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,8 @@ jobs:
           dotnetbuilds.azureedge.net:443
           dotnetcli.azureedge.net:443
           github.com:443
+          objects.githubusercontent.com:443
+          uploads.github.com:443
 
     - name: Checkout repository
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
Adding missing endpoints for push action