### PR TITLE
chore: Add tuf-repo-cdn.sigstore.dev to allowed endpoints

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,7 @@ jobs:
             oss-fuzz-build-logs.storage.googleapis.com:443
             sigstore-tuf-root.storage.googleapis.com:443
             rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
(This should fix the GitHub Action, I believe.)