### PR TITLE
chore: add conformance test coverage for typed function signature

### DIFF
--- a/run-conformance-tests.sh
+++ b/run-conformance-tests.sh
@@ -67,8 +67,9 @@ echo "Using Functions Framework test binary: $DOTNET_DLL"
 # Run the tests
 run_test() {
   TEST_TYPE=$1
-  TEST_FUNCTION=$2
-  EXTRA_ARGS=$3
+  DECLARATIVE_TYPE=$2
+  TEST_FUNCTION=$3
+  EXTRA_ARGS=$4
   echo "Running '$TEST_TYPE' test with function '$TEST_FUNCTION'"
   (cd tmp/conformance-test-output && \
    mkdir $TEST_FUNCTION && \
@@ -76,13 +77,15 @@ run_test() {
    ../../../$CLIENT_BINARY \
      -buildpacks=false \
      -type=$TEST_TYPE \
+     -declarative-type=$DECLARATIVE_TYPE \
      -cmd="dotnet ../../../$DOTNET_DLL $TEST_FUNCTION" \
      $EXTRA_ARGS
   )
 }
 
-run_test http HttpFunction
-run_test cloudevent UntypedCloudEventFunction
-run_test http ConcurrentHttpFunction -validate-concurrency=true
+run_test http http HttpFunction
+run_test http typed TypedFunction
+run_test cloudevent cloudevent UntypedCloudEventFunction
+run_test http http ConcurrentHttpFunction -validate-concurrency=true
 
 echo "Tests completed successfully"

--- a/src/Google.Cloud.Functions.ConformanceTests/TypedFunction.cs
+++ b/src/Google.Cloud.Functions.ConformanceTests/TypedFunction.cs
@@ -1,0 +1,38 @@
+// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Functions.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using System.Dynamic;
+
+// Note: no namespace, to make it simpler to run as part of conformance testing
+public class TypedFunction : ITypedFunction<ConformanceRequest, ConformanceResponse>
+{
+    public Task<ConformanceResponse> HandleAsync(ConformanceRequest request, CancellationToken cancellationToken) =>
+        Task.FromResult(new ConformanceResponse { Payload = request });
+}
+
+public class ConformanceRequest
+{
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+}
+
+public class ConformanceResponse
+{
+    [JsonPropertyName("payload")]
+    public dynamic Payload { get; set; }
+}


### PR DESCRIPTION
Changes

 * Adds new conformance test function `TypedFunction` using the typed function signature.
 * Updates conformance client version to the latest release with support for typed function conformance testing.
 * Updates `run-conformance-tests.sh` to include the new test.

The new test expects a function to be called with a JSON object `{"a":"b"}` and to return that payload as a `payload` field of its response i.e. `{"payload": {"a": "b"}}`.