### PR TITLE
fix(readme): min dotnet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ different environments, including:
 
 ## Prerequisites
 
-The Functions Framework for .NET requires the [.NET Core SDK 3.1](https://dotnet.microsoft.com/download).
+The Functions Framework for .NET requires the [.NET 6.0](https://dotnet.microsoft.com/download) or later.
 
 ## Quickstarts
 


### PR DESCRIPTION
From version 2.0.0 of the package .NET 6 became the min version: https://www.nuget.org/packages/Google.Cloud.Functions.Hosting/2.0.0#supportedframeworks-body-tab