### PR TITLE
chore: Update SBOM generator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "Google.Cloud.Tools.SbomGenerator": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "commands": [
         "generate-sbom"
       ]

--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -45,9 +45,16 @@ then
   echo "Pushing NuGet packages"
   # Push the changes to nuget.
   cd ./tmp/release/nupkg
+  
+  # First generate all the SBOMs.
   for pkg in *.nupkg
   do
     dotnet generate-sbom $pkg
+  done
+  
+  # Only start pushing to NuGet when SBOM generation has succeeded.
+  for pkg in *.nupkg
+  do
     dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY $pkg
   done
   cd ../../..


### PR DESCRIPTION
Release 2.2.1 contains the same code as 2.2.0, but the 2.2.0 release failed after only releasing some of the packages. The 2.2.1 release should be complete with all packages.

This commit updates the SBOM generator to the latest version, and changes the build script to avoid similar partial failures in the future.

Release-As: 2.2.1