### PR TITLE
chore: Update Microsoft.AspNetCore.TestHost dependency

### DIFF
--- a/src/Google.Cloud.Functions.Testing/Google.Cloud.Functions.Testing.csproj
+++ b/src/Google.Cloud.Functions.Testing/Google.Cloud.Functions.Testing.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.29" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.30" />
     <ProjectReference Include="..\Google.Cloud.Functions.Hosting\Google.Cloud.Functions.Hosting.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
So that we can close #524 which is currently an inmortal PR.