### PR TITLE
chore: Update Microsoft.AspNetCore.TestHost dependency

### DIFF
--- a/src/Google.Cloud.Functions.Testing/Google.Cloud.Functions.Testing.csproj
+++ b/src/Google.Cloud.Functions.Testing/Google.Cloud.Functions.Testing.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.31" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.32" />
     <ProjectReference Include="..\Google.Cloud.Functions.Hosting\Google.Cloud.Functions.Hosting.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
So that #551 is not inmortal and we can close it.