### PR TITLE
chore: Explicitly install .NET 6 for the CodeQL test

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,10 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '6.0.x'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Previously we were just using whatever version was present, which included .NET 6 - but not that .NET 6 is deprecated, we need to install it explicitly.

(We'll change all of this when we retarget to .NET 8, which should be soon.)

Fixes b/388692803