### PR TITLE
fix: Update project references in templates

### DIFF
--- a/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.AdvancedDependencyInjection/Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Configuration/Google.Cloud.Functions.Examples.Configuration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomConfiguration/Google.Cloud.Functions.Examples.CustomConfiguration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.RandomValueBase" Version="3.2.8" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.CustomEventDataFunction/Google.Cloud.Functions.Examples.CustomEventDataFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.8.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpEventFunction/Google.Cloud.Functions.Examples.FSharpEventFunction.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.7.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpHttpFunction/Google.Cloud.Functions.Examples.FSharpHttpFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
+++ b/examples/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction/Google.Cloud.Functions.Examples.FSharpUntypedEventFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
+++ b/examples/Google.Cloud.Functions.Examples.IntegrationTests/Google.Cloud.Functions.Examples.IntegrationTests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="3.0.0" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.AdvancedDependencyInjection\Google.Cloud.Functions.Examples.AdvancedDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleDependencyInjection\Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj" />
     <ProjectReference Include="..\Google.Cloud.Functions.Examples.SimpleHttpFunction\Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj" />

--- a/examples/Google.Cloud.Functions.Examples.LocalNuGetPackageFunction/Google.Cloud.Functions.Examples.LocalNuGetPackageFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.LocalNuGetPackageFunction/Google.Cloud.Functions.Examples.LocalNuGetPackageFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
     
     <!-- This package is in the nupkg directory, referenced in nuget.config -->

--- a/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
+++ b/examples/Google.Cloud.Functions.Examples.Middleware/Google.Cloud.Functions.Examples.Middleware.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.MultiProjectFunction/Google.Cloud.Functions.Examples.MultiProjectFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleDependencyInjection/Google.Cloud.Functions.Examples.SimpleDependencyInjection.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleEventFunction/Google.Cloud.Functions.Examples.SimpleEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.7.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleHttpFunction/Google.Cloud.Functions.Examples.SimpleHttpFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
+++ b/examples/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction/Google.Cloud.Functions.Examples.SimpleUntypedEventFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
+++ b/examples/Google.Cloud.Functions.Examples.StorageImageAnnotator/Google.Cloud.Functions.Examples.StorageImageAnnotator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.11.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="3.7.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.7.0" />

--- a/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TestableDependencies/Google.Cloud.Functions.Examples.TestableDependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
+++ b/examples/Google.Cloud.Functions.Examples.TimeZoneConverter/Google.Cloud.Functions.Examples.TimeZoneConverter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="NodaTime" Version="3.2.2" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbEventFunction/Google.Cloud.Functions.Examples.VbEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.7.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbHttpFunction/Google.Cloud.Functions.Examples.VbHttpFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
+++ b/examples/Google.Cloud.Functions.Examples.VbUntypedEventFunction/Google.Cloud.Functions.Examples.VbUntypedEventFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.8.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-fs/MyFunction.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.8.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-fs/MyFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/http-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-cs/MyFunction.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-fs/MyFunction.fsproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
+++ b/src/Google.Cloud.Functions.Templates/templates/untyped-event-function-vb/MyFunction.vbproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="3.0.0" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This should have happened automatically for the 3.0.0 release. This change updates them to 3.0.0, but then we'll need to release a new version of everything, making sure the release PR for that updates the templates *again*.

Release-As: 3.0.1